### PR TITLE
Delete dead check_pkgs_availability

### DIFF
--- a/grayskull/base/pkg_info.py
+++ b/grayskull/base/pkg_info.py
@@ -1,6 +1,4 @@
-import re
 from functools import lru_cache
-from typing import List, Optional, Tuple
 
 import requests
 
@@ -27,35 +25,3 @@ def normalize_pkg_name(pkg_name: str) -> str:
     elif is_pkg_available(pkg_name.replace("_", "-")):
         return pkg_name.replace("_", "-")
     return pkg_name
-
-
-def check_pkgs_availability(
-    list_pkgs: List[str], channel: Optional[str] = None
-) -> List[Tuple[str, bool]]:
-    """Check if the list is
-
-    :param list_pkgs: List with packages name
-    :return:
-    """
-    list_pkgs.sort()
-    re_search = re.compile(r"^\s*[a-z0-9\.\-\_]+", re.IGNORECASE)
-
-    result_list = []
-    all_pkg = set()
-    for pkg in list_pkgs:
-        if not pkg:
-            continue
-        search_result = re_search.search(pkg)
-        if not search_result:
-            continue
-
-        pkg_name = search_result.group()
-        if pkg_name in all_pkg:
-            continue
-
-        all_pkg.add(pkg_name)
-        if channel:
-            result_list.append((pkg, is_pkg_available(pkg_name, channel)))
-        else:
-            result_list.append((pkg, is_pkg_available(pkg_name)))
-    return result_list

--- a/tests/base/test_pkg_info.py
+++ b/tests/base/test_pkg_info.py
@@ -1,4 +1,4 @@
-from grayskull.base.pkg_info import check_pkgs_availability, is_pkg_available
+from grayskull.base.pkg_info import is_pkg_available
 
 
 def test_pkg_available():
@@ -7,23 +7,3 @@ def test_pkg_available():
 
 def test_pkg_not_available():
     assert not is_pkg_available("NOT_PACKAGE_654987321")
-
-
-def test_check_pkgs_availability(capsys):
-    all_pkgs = check_pkgs_availability(
-        [
-            "pytest >=4.0.0,<5.0.0  # [win]",
-            "requests",
-            "pandas[test]",
-            "NOT_PACKAGE_13248743",
-        ]
-    )
-
-    assert sorted(all_pkgs) == sorted(
-        [
-            ("pytest >=4.0.0,<5.0.0  # [win]", True),
-            ("requests", True),
-            ("pandas[test]", True),
-            ("NOT_PACKAGE_13248743", False),
-        ]
-    )


### PR DESCRIPTION
I was looking through the source, and as far as I can tell, `check_pkgs_availability` is not used anywhere. Perhaps it can be removed?