### PR TITLE
Use `{{ name }}` in filename too

### DIFF
--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -134,7 +134,11 @@ def get_url_filename(metadata: dict, default: Optional[str] = None) -> str:
         if pkg_url["packagetype"] == "sdist":
             name = metadata["info"]["name"]
             version = metadata["info"]["version"]
-            return pkg_url["filename"].replace(name, "{{ name }}").replace(version, "{{ version }}")
+            return (
+                pkg_url["filename"]
+                .replace(name, "{{ name }}")
+                .replace(version, "{{ version }}")
+            )
     return default
 
 

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -132,8 +132,9 @@ def get_url_filename(metadata: dict, default: Optional[str] = None) -> str:
 
     for pkg_url in metadata["urls"]:
         if pkg_url["packagetype"] == "sdist":
+            name = metadata["info"]["name"]
             version = metadata["info"]["version"]
-            return pkg_url["filename"].replace(version, "{{ version }}")
+            return pkg_url["filename"].replace(name, "{{ name }}").replace(version, "{{ version }}")
     return default
 
 


### PR DESCRIPTION
### Description

Since `{{ name }}` is already templated elsewhere, template it in the filename of the archive too for consistency.

Note: This behavior was observed in comment ( https://github.com/conda-forge/staged-recipes/pull/22395#discussion_r1149935851 )