### PR TITLE
Add data-morph-ai exception to config.yaml

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -90,6 +90,10 @@ dask:
   conda_forge: dask-core
   import_name: dask
 
+data-morph-ai:
+  conda_forge: data-morph-ai
+  import_name: data_morph
+
 datadotworld:
   conda_forge: datadotworld-py
   import_name: datadotworld


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
I published a recipe to conda-forge using the same distribution name as PyPI for consistency (`data-morph-ai`), but since this doesn't match the name of the package (`data_morph`), I had an issue with the mapping of the distribution name to the package name using `grayskull`. Here's the package on [PyPI](https://pypi.org/project/data-morph-ai/) and [conda-forge](https://anaconda.org/conda-forge/data-morph-ai).