### PR TITLE
align with current standard build script command

### DIFF
--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -59,7 +59,7 @@ class PypiStrategy(AbstractStrategy):
     def fetch_data(recipe, config, sections=None):
         update_recipe(recipe, config, sections or ALL_SECTIONS)
         if not (recipe["build"] and recipe["build"]["script"]):
-            recipe["build"]["script"] = "<{ PYTHON }} -m pip install . -vv"
+            recipe["build"]["script"] = "<{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
 
 
 def merge_pypi_sdist_metadata(

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -59,7 +59,9 @@ class PypiStrategy(AbstractStrategy):
     def fetch_data(recipe, config, sections=None):
         update_recipe(recipe, config, sections or ALL_SECTIONS)
         if not (recipe["build"] and recipe["build"]["script"]):
-            recipe["build"]["script"] = "<{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+            recipe["build"][
+                "script"
+            ] = "<{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
 
 
 def merge_pypi_sdist_metadata(

--- a/tests/data/poetry/langchain-expected.yaml
+++ b/tests/data/poetry/langchain-expected.yaml
@@ -13,7 +13,7 @@ build:
   entry_points:
     - langchain-server = langchain.server:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

As per current package building standards, `--no-deps` and `--no-build-isolation` should be used by default in the build script section of the recipe.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
