### PR TITLE
Add name mapping for gssapi

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -496,3 +496,7 @@ jupyter-client:
 flit_core:
   conda_forge: flit-core
   import_name: flit-core
+
+gssapi:
+  conda_forge: python-gssapi
+  import_name: gssapi


### PR DESCRIPTION
### Description

This PR adds a pypi<->conda-forge name mapping for `gssapi`.

References:

- https://pypi.org/project/gssapi/
- https://anaconda.org/conda-forge/python-gssapi