### PR TITLE
Add quirk for (`python-`)`eccodes`

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -118,6 +118,10 @@ dye_score:
   conda_forge: dye-score
   import_name: dye_score
 
+eccodes:
+  conda_forge: python-eccodes
+  import_name: eccodes
+
 empyrical_dist:
   conda_forge: empyrical-dist
   import_name: empyrical_dist


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The conda-forge package [python-eccodes](https://github.com/conda-forge/python-eccodes-feedstock) is the PyPI package [eccodes](https://pypi.org/project/eccodes/).  There is a C/C++/Fortran package on conda-forge called [eccodes](https://github.com/conda-forge/eccodes-feedstock), so it is particularly confusing when this package gets used as an unintentional dependency.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
