### PR TITLE
Add (`python-`)`build` to quirks

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -42,6 +42,10 @@ bash_completion:
   conda_forge: py-bash-completion
   import_name: bash_completion
 
+build:
+  conda_forge: python-build
+  import_name: build
+
 captest:
   conda_forge: pvcaptest
   import_name: captest


### PR DESCRIPTION
The conda-forge package [python-build](https://github.com/conda-forge/python-build-feedstock) is the PyPI package [build](https://pypi.org/project/build/) (and not the PyPI package [python-build](https://pypi.org/project/python-build/), which hasn't been updated in 7 years). There is an archived feedstock on conda-forge for [build](https://github.com/conda-forge/build-feedstock) that we do not want to be using.