### PR TITLE
prototype implementation of interpreting PEP725 metadata

### DIFF
--- a/grayskull/cli/stdout.py
+++ b/grayskull/cli/stdout.py
@@ -8,6 +8,7 @@ from colorama import Fore, Style
 
 from grayskull.base.pkg_info import is_pkg_available
 from grayskull.cli import WIDGET_BAR_DOWNLOAD, CLIConfig
+from grayskull.utils import RE_PEP725_PURL
 
 
 def print_msg(msg: str):
@@ -78,6 +79,11 @@ def print_requirements(
                 pkg_name = pkg.replace("<{", "{{")
                 options = ""
                 colour = Fore.GREEN
+            elif RE_PEP725_PURL.match(pkg):
+                pkg_name = pkg
+                options = ""
+                all_missing_deps.add(pkg)
+                colour = Fore.YELLOW
             elif search_result:
                 pkg_name, options = search_result.groups()
                 if is_pkg_available(pkg_name):
@@ -102,7 +108,15 @@ def print_requirements(
         print_msg(f"{key.capitalize()} requirements (optional):")
         print_req(req_list)
 
-    print_msg(f"\n{Fore.RED}RED{Style.RESET_ALL}: Missing packages")
+    print_msg(
+        f"\n{Fore.RED}RED{Style.RESET_ALL}: Package names not available on conda-forge"
+    )
+    print_msg(
+        (
+            f"{Fore.YELLOW}YELLOW{Style.RESET_ALL}: "
+            "PEP-725 PURLs that did not map to known package"
+        )
+    )
     print_msg(f"{Fore.GREEN}GREEN{Style.RESET_ALL}: Packages available on conda-forge")
 
     if CLIConfig().list_missing_deps:

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -111,6 +111,7 @@ def merge_pypi_sdist_metadata(
         "requires_dist": requires_dist,
         "sdist_path": get_val("sdist_path"),
         "requirements_run_constrained": get_val("requirements_run_constrained"),
+        "__build_requirements_placeholder": get_val("__build_requirements_placeholder"),
     }
 
 
@@ -556,6 +557,8 @@ def extract_requirements(metadata: dict, config, recipe) -> Dict[str, List[str]]
     requires_dist = format_dependencies(metadata.get("requires_dist", []), name)
     setup_requires = metadata.get("setup_requires", [])
     host_req = format_dependencies(setup_requires or [], config.name)
+    build_requires = metadata.get("__build_requirements_placeholder", [])
+    build_req = format_dependencies(build_requires or [], config.name)
     if not requires_dist and not host_req and not metadata.get("requires_python"):
         if config.is_strict_cf:
             py_constrain = (
@@ -571,7 +574,9 @@ def extract_requirements(metadata: dict, config, recipe) -> Dict[str, List[str]]
 
     run_req = get_run_req_from_requires_dist(requires_dist, config)
     host_req = get_run_req_from_requires_dist(host_req, config)
-    build_req = [f"<{{ compiler('{c}') }}}}" for c in metadata.get("compilers", [])]
+    build_req = build_req or [
+        f"<{{ compiler('{c}') }}}}" for c in metadata.get("compilers", [])
+    ]
     if build_req:
         config.is_arch = True
 

--- a/grayskull/utils.py
+++ b/grayskull/utils.py
@@ -24,6 +24,10 @@ yaml.indent(mapping=2, sequence=4, offset=2)
 yaml.width = 600
 
 
+#  PURL fields               scheme      type           name
+RE_PEP725_PURL = re.compile(r"[a-z]+\:[\.a-z0-9_-]+\/[\.a-z0-9_-]+", re.IGNORECASE)
+
+
 @lru_cache(maxsize=10)
 def get_std_modules() -> List:
     from stdlib_list import stdlib_list
@@ -167,6 +171,9 @@ def format_dependencies(all_dependencies: List, name: str) -> List:
     re_remove_tags = re.compile(r"\s*(\[.*\])", re.DOTALL)
     re_remove_comments = re.compile(r"\s+#.*", re.DOTALL)
     for req in all_dependencies:
+        if RE_PEP725_PURL.match(req):
+            formatted_dependencies.append(req)
+            continue
         match_req = re_deps.match(req)
         deps_name = req
         if name is not None and deps_name.replace("-", "_") == name.replace("-", "_"):
@@ -218,11 +225,6 @@ def generate_recipe(
         name = file_to_recipe.split(os.path.sep)[-1]
         if os.path.isfile(file_to_recipe):
             copyfile(file_to_recipe, os.path.join(recipe_folder, name))
-
-
-def get_clean_yaml(recipe_yaml: CommentedMap) -> CommentedMap:
-    clean_yaml(recipe_yaml)
-    return add_new_lines_after_section(recipe_yaml)
 
 
 def add_new_lines_after_section(recipe_yaml: CommentedMap) -> CommentedMap:

--- a/tests/test_flit.py
+++ b/tests/test_flit.py
@@ -1,8 +1,0 @@
-from grayskull.strategy.py_toml import add_flit_metadata
-
-
-def test_add_flit_metadata():
-    metadata = {"build": {"entry_points": []}}
-    toml_metadata = {"tool": {"flit": {"scripts": {"key": "value"}}}}
-    result = add_flit_metadata(metadata, toml_metadata)
-    assert result == {"build": {"entry_points": ["key = value"]}}

--- a/tests/test_py_toml.py
+++ b/tests/test_py_toml.py
@@ -8,6 +8,8 @@ import pytest
 from grayskull.main import generate_recipes_from_list, init_parser
 from grayskull.strategy.py_toml import (
     InvalidVersion,
+    add_flit_metadata,
+    add_pep725_metadata,
     add_poetry_metadata,
     encode_poetry_version,
     get_all_toml_info,
@@ -16,6 +18,13 @@ from grayskull.strategy.py_toml import (
     get_tilde_ceiling,
     parse_version,
 )
+
+
+def test_add_flit_metadata():
+    metadata = {"build": {"entry_points": []}}
+    toml_metadata = {"tool": {"flit": {"scripts": {"key": "value"}}}}
+    result = add_flit_metadata(metadata, toml_metadata)
+    assert result == {"build": {"entry_points": ["key = value"]}}
 
 
 @pytest.mark.parametrize(
@@ -160,7 +169,7 @@ def test_poetry_langchain_snapshot(tmpdir):
     assert filecmp.cmp(snapshot_path, output_path, shallow=False)
 
 
-def test_get_constrained_dep_version_not_present():
+def test_poetry_get_constrained_dep_version_not_present():
     assert (
         get_constrained_dep(
             {"git": "https://codeberg.org/hjacobs/pytest-kind.git"}, "pytest-kind"
@@ -169,7 +178,7 @@ def test_get_constrained_dep_version_not_present():
     )
 
 
-def test_entrypoints():
+def test_poetry_entrypoints():
     poetry = {
         "requirements": {"host": ["setuptools"], "run": ["python"]},
         "build": {},
@@ -197,4 +206,26 @@ def test_entrypoints():
             ]
         },
         "test": {},
+    }
+
+
+@pytest.mark.parametrize(
+    "conda_section, pep725_section",
+    [("build", "build-requires"), ("host", "host-requires"), ("run", "dependencies")],
+)
+@pytest.mark.parametrize(
+    "purl, purl_translated",
+    [
+        ("virtual:compiler/c", "{{ compiler('c') }}"),
+        ("pkg:alice/bob", "pkg:alice/bob"),
+    ],
+)
+def test_pep725_section_lookup(conda_section, pep725_section, purl, purl_translated):
+    toml_metadata = {
+        "external": {
+            pep725_section: [purl],
+        }
+    }
+    assert add_pep725_metadata({}, toml_metadata) == {
+        "requirements": {conda_section: [purl_translated]}
     }


### PR DESCRIPTION
In https://discuss.python.org/t/pep-725-specifying-external-dependencies-in-pyproject-toml/31888/40, I offered to prototype an implementation of PEP725 for Grayskull. Here we are!

PEP 725 is the PEP to allow expression of external dependencies in pyproject.toml. It basically boils down to a grand scheme to unify a translation table across the many ecosystems. This PR should be interpreted in the context of the discussion at https://discuss.python.org/t/pep-725-specifying-external-dependencies-in-pyproject-toml/31888

This prototype demonstrates the name mapping, but this won't be a real implementation until a definitive name map is created for conda-forge (and perhaps elsewhere).

I have taken the liberty of consolidating test_flit.py and test_poetry.py into test_py_toml.py, because I found the difference between the implementation in the one file (py_toml.py) vs the split-up test implementation to make things harder to find.

CC @rgommers

Update: after all revisions and fumbling, the design here is:

1. [extract external dependencies from pyproject.toml](https://github.com/conda/grayskull/pull/518/files#diff-fb6b818bcb86e6ebb8733757d7942b0ca48568ee9b0f356de25c5e89fd4e1617R267)
2. [Merge these external dependencies with setup.py/setup.cfg metadata. The build dependencies don't have an equivalent in setup.py/setup.cfg, so we make a separate placeholder for them.](https://github.com/conda/grayskull/pull/518/files#diff-4979c2f9f40da9b20e55dbfe2dece4e1ab40a416a6ded5a8f63b11d9195e110cR744)
3. [get the merged dependencies for the conda recipe requirements](https://github.com/conda/grayskull/pull/518/files#diff-920d6d6f47cb26975a6c1349bae92c12c6db11ed9f46c63a29162c19926e7ccbR560)
4. If any PURL patterns remain in the generated recipe, they are [highlighted in yellow](https://github.com/conda/grayskull/pull/518/files#diff-890f06af677cf1c1c1892f303df4f04041a602ff497012a80d63f0c914d5739aR82). This yellow color is [added to the key]( https://github.com/conda/grayskull/pull/518/files#diff-890f06af677cf1c1c1892f303df4f04041a602ff497012a80d63f0c914d5739aR116)

I think we might want to set a non-zero return code if there are any dependencies not found or PURLs not mapped, but that would be a behavior change. I did not want to get into that with this PR.