### PR TITLE
Add quirk for (`python-`)`dashing`

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -90,6 +90,10 @@ cufflinks:
   conda_forge: python-cufflinks
   import_name: cufflinks
 
+dashing:
+  conda_forge: python-dashing
+  import_name: dashing
+
 dask:
   conda_forge: dask-core
   import_name: dask


### PR DESCRIPTION
This was just merged to conda-forge and needs this quirk because of a nameclash with `bioconda`.