### PR TITLE
Support Python-version-specific deps in poetry

### DIFF
--- a/grayskull/strategy/py_toml.py
+++ b/grayskull/strategy/py_toml.py
@@ -172,6 +172,9 @@ def __get_constrained_dep_dict(dep_spec: dict, dep_name: str):
             )
         elif m := re.match(r">=(\d)\.(\d+)", dep_spec["python"]):
             python_selector = f"  # [py>={m.group(1)}{m.group(2)}]"
+        elif m := re.match(r"\^(\d)\.(\d+)", dep_spec["python"]):
+            next_major = (int(m.group(1)) + 1) * 100
+            python_selector = f"  # [py>={m.group(1)}{m.group(2)} and py<{next_major}]"
         else:
             raise ValueError(
                 f"Unsupported Python version expression: {dep_spec['python']}"

--- a/tests/data/poetry/langchain-expected.yaml
+++ b/tests/data/poetry/langchain-expected.yaml
@@ -12,17 +12,16 @@ source:
 build:
   entry_points:
     - langchain-server = langchain.server:main
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.8,<4.0
+    - python
     - poetry-core
     - pip
   run:
-    - python >=3.8.1,<4.0
+    - python
     - pydantic >=1.0.0,<2.0.0
     - sqlalchemy >=1.0.0,<2.0.0
     - requests >=2.0.0,<3.0.0
@@ -44,14 +43,14 @@ requirements:
     - beautifulsoup4 >=4.0.0,<5.0.0
     - pytorch >=1.0.0,<2.0.0
     - jinja2 >=3.0.0,<4.0.0
-    - tiktoken >=0.0.0,<1.0.0
+    - tiktoken >=0.0.0,<1.0.0  # [py>=39 and py<400]
     - pinecone-client >=2.0.0,<3.0.0
     - weaviate-client >=3.0.0,<4.0.0
     - google-api-python-client 2.70.0
     - wolframalpha 5.0.0
     - anthropic >=0.2.2,<0.3.0
-    - qdrant-client >=1.0.4,<2.0.0
-    - tensorflow-text >=2.11.0,<3.0.0
+    - qdrant-client >=1.0.4,<2.0.0  # [py>=38]
+    - tensorflow-text >=2.11.0,<3.0.0  # [py>=310 and py<400]
     - cohere >=3.0.0,<4.0.0
     - openai >=0.0.0,<1.0.0
     - nlpcloud >=1.0.0,<2.0.0

--- a/tests/data/poetry/poetry.toml
+++ b/tests/data/poetry/poetry.toml
@@ -34,6 +34,10 @@ python = "^3.7"
 cleo = "^2.0.0"
 html5lib = "^1.0"
 urllib3 = "^1.26.0"
+scikit-learn = [
+    {version="^1.0.2", python=">=3.7,<3.8"},
+    {version="^1.2", python=">=3.8,<3.12"}
+]
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.6"

--- a/tests/test_poetry.py
+++ b/tests/test_poetry.py
@@ -141,6 +141,8 @@ def test_poetry_dependencies():
         "cleo >=2.0.0,<3.0.0",
         "html5lib >=1.0.0,<2.0.0",
         "urllib3 >=1.26.0,<2.0.0",
+        "scikit-learn >=1.0.2,<2.0.0  # [py>=37 and py<38]",
+        "scikit-learn >=1.2.0,<2.0.0  # [py>=38 and py<312]",
     ]
 
 


### PR DESCRIPTION
Poetry also supports dependencies depending on the Python version. I have encountered this in the `nannyml` package.