### PR TITLE
Attempt to fix some URL bugs

### DIFF
--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -564,7 +564,7 @@ def discover_license(metadata: dict) -> List[ShortLicense]:
     the license.
     """
     git_url = metadata.get("dev_url")
-    project_url = metadata.get("project_urls", "") or metadata.get("project_url", "")
+    project_url = metadata.get("project_url", "")
     if not git_url and urlparse(project_url).netloc == "github.com":
         git_url = project_url
     # "url" is always present but sometimes set to None
@@ -716,7 +716,7 @@ def merge_setup_toml_metadata(setup_metadata: dict, pyproject_metadata: dict) ->
     if pyproject_metadata["about"]["summary"]:
         setup_metadata["summary"] = pyproject_metadata["about"]["summary"]
     if pyproject_metadata["about"]["home"]:
-        setup_metadata["projects_url"]["Homepage"] = pyproject_metadata["about"]["home"]
+        setup_metadata["project_urls"]["Homepage"] = pyproject_metadata["about"]["home"]
     if pyproject_metadata["build"]["entry_points"]:
         setup_metadata["entry_points"]["console_scripts"] = pyproject_metadata["build"][
             "entry_points"

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -418,7 +418,7 @@ def get_metadata(recipe, config) -> dict:
         doc_url = metadata["docs_url"]
     else:
         doc_url = None
-        
+
     if metadata.get("project_urls") and metadata["project_urls"].get("Source"):
         dev_url = metadata["project_urls"]["Source"]
     elif metadata.get("dev_url"):

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -101,12 +101,13 @@ def merge_pypi_sdist_metadata(
             pypi_metadata.get("requires_python")
             or sdist_metadata.get("python_requires")
         ),
-        "doc_url": get_val("doc_url"),
+        "docs_url": get_val("docs_url"),
         "dev_url": get_val("dev_url"),
         "license": get_val("license"),
         "setup_requires": get_val("setup_requires"),
         "extra_requires": get_val("extra_requires"),
         "project_url": get_val("project_url"),
+        "project_urls": get_val("project_urls"),
         "extras_require": get_val("extras_require"),
         "requires_dist": requires_dist,
         "sdist_path": get_val("sdist_path"),
@@ -270,7 +271,6 @@ def get_pypi_metadata(config: Configuration) -> dict:
             json.dump(metadata, f, indent=4)
         config.files_to_copy.append(download_file)
     info = metadata["info"]
-    project_urls = info.get("project_urls") or {}
     log.info(f"Package: {config.name}=={info['version']}")
     log.debug(f"Full PyPI metadata:\n{metadata}")
     sdist_url = get_sdist_url_from_pypi(metadata)
@@ -282,10 +282,10 @@ def get_pypi_metadata(config: Configuration) -> dict:
         "requires_dist": info.get("requires_dist", []),
         "requires_python": info.get("requires_python", None),
         "summary": info.get("summary"),
-        "project_urls": info.get("project_urls") or info.get("project_url"),
-        "doc_url": info.get("docs_url"),
-        "dev_url": project_urls.get("Source"),
-        "url": info.get("home_page"),
+        "project_url": info.get("project_url"),
+        "project_urls": info.get("project_urls") or {},
+        "docs_url": info.get("docs_url"),
+        "home_page": info.get("home_page"),
         "license": info.get("license"),
         "source": {
             "url": "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/"
@@ -401,11 +401,36 @@ def get_metadata(recipe, config) -> dict:
     test_requirements = optional_requirements.pop(config.extras_require_test, [])
     test_section = compose_test_section(metadata, test_requirements)
 
+    # Compute home, doc_url, and dev_url for the "about" section
+
+    if metadata.get("project_urls") and metadata["project_urls"].get("Homepage"):
+        home = metadata["project_urls"]["Homepage"]
+    elif metadata.get("project_url"):
+        home = metadata["project_url"]
+    elif metadata.get("url"):
+        home = metadata["url"]
+    else:
+        home = None
+
+    if metadata.get("project_urls") and metadata["project_urls"].get("Documentation"):
+        doc_url = metadata["project_urls"]["Documentation"]
+    elif metadata.get("docs_url"):
+        doc_url = metadata["docs_url"]
+    else:
+        doc_url = None
+        
+    if metadata.get("project_urls") and metadata["project_urls"].get("Source"):
+        dev_url = metadata["project_urls"]["Source"]
+    elif metadata.get("dev_url"):
+        dev_url = metadata["dev_url"]
+    else:
+        dev_url = None
+
     about_section = {
-        "home": metadata["url"] if metadata.get("url") else metadata.get("project_url"),
+        "home": home,
         "summary": metadata.get("summary"),
-        "doc_url": metadata.get("doc_url"),
-        "dev_url": metadata.get("dev_url"),
+        "doc_url": doc_url,
+        "dev_url": dev_url,
         "license": license_name,
         "license_file": license_file,
     }


### PR DESCRIPTION
### Description

I made a quick attempt to fix #447, but it's not working yet. Output looks like:

```yaml
{% set name = "pyospackage" %}
{% set version = "0.1.10" %}

package:
  name: {{ name|lower }}
  version: {{ version }}

source:
  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyospackage-{{ version }}.tar.gz
  sha256: b16fa74b9d3659609bde00fd6f1f7973ea15a47e41fdbd911f0666250feb95d9

build:
  noarch: python
  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
  number: 0

requirements:
  host:
    - python >=3.9
    - hatchling
    - pip
  run:
    - python >=3.9

test:
  imports:
    - pyospackage
  commands:
    - pip check
  requires:
    - pip

about:
  home: https://pypi.org/project/pyospackage/
  summary: A package that adds numbers together
  doc_url: https://github.com/pyopensci/pyospackage
 # readme
  dev_url: https://github.com/pyopensci/pyospackage
 # readme
  license: MIT
 # readme
  license_file: LICENSE  # readme

extra:
  recipe-maintainers:
    - maresb
```

I'm not sure where those `# readme` comments are coming from, and I'm not sure why the `doc_url` gets clobbered during the rendering. (It's correct when `about_section` is defined.)