### PR TITLE
Add `h3(-py)` quirk

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -194,6 +194,10 @@ h2o:
   conda_forge: h2o-py
   import_name: h2o
 
+h3:
+  conda_forge: h3-py
+  import_name: h3
+
 hdfs:
   conda_forge: python-hdfs
   import_name: hdfs


### PR DESCRIPTION
This quirk would be helpful e.g. for:
https://github.com/conda-forge/timezonefinder-feedstock/pull/66