### PR TITLE
Add more package mappings for PEP 725

### DIFF
--- a/grayskull/strategy/py_toml.py
+++ b/grayskull/strategy/py_toml.py
@@ -260,6 +260,54 @@ def get_pep725_mapping(purl: str):
         "virtual:compiler/fortran": "{{ compiler('fortran') }}",
         "virtual:compiler/rust": "{{ compiler('rust') }}",
         "virtual:interface/blas": "{{ blas }}",
+        "pkg:generic/boost": "boost-cpp",
+        "pkg:generic/brial": "brial",
+        "pkg:generic/cddlib": "cddlib",
+        "pkg:generic/cliquer": "cliquer",
+        "pkg:generic/ecl": "ecl",
+        "pkg:generic/eclib": "eclib",
+        "pkg:generic/ecm": "ecm",
+        "pkg:generic/fflas-ffpack": "fflas-ffpack",
+        "pkg:generic/fplll": "fplll",
+        "pkg:generic/flint": "libflint",
+        "pkg:generic/libgd": "libgd",
+        "pkg:generic/gap": "gap-defaults",
+        "pkg:generic/gfan": "gfan",
+        "pkg:generic/gmp": "gmp",
+        "pkg:generic/giac": "giac",
+        "pkg:generic/givaro": "givaro",
+        "pkg:generic/pkg-config": "pkg-config",
+        "pkg:generic/glpk": "glpk",
+        "pkg:generic/gsl": "gsl",
+        "pkg:generic/iml": "iml",
+        "pkg:generic/lcalc": "lcalc",
+        "pkg:generic/libbraiding": "libbraiding",
+        "pkg:generic/libhomfly": "libhomfly",
+        "pkg:generic/lrcalc": "lrcalc",
+        "pkg:generic/libpng": "libpng",
+        "pkg:generic/linbox": "linbox",
+        "pkg:generic/m4ri": "m4ri",
+        "pkg:generic/m4rie": "m4rie",
+        "pkg:generic/mpc": "mpc",
+        "pkg:generic/mpfi": "mpfi",
+        "pkg:generic/mpfr": "mpfr",
+        "pkg:generic/maxima": "maxima",
+        "pkg:generic/nauty": "nauty",
+        "pkg:generic/ntl": "ntl",
+        "pkg:generic/pari": "pari",
+        "pkg:generic/pari-elldata": "pari-elldata",
+        "pkg:generic/pari-galdata": "pari-galdata",
+        "pkg:generic/pari-seadata": "pari-seadata",
+        "pkg:generic/palp": "palp",
+        "pkg:generic/planarity": "planarity",
+        "pkg:generic/ppl": "ppl",
+        "pkg:generic/primesieve": "primesieve",
+        "pkg:generic/primecount": "primecount",
+        "pkg:generic/qhull": "qhull",
+        "pkg:generic/rw": "rw",
+        "pkg:generic/singular": "singular",
+        "pkg:generic/symmetrica": "symmetrica",
+        "pkg:generic/sympow": "sympow",
     }
     return package_mapping.get(purl, purl)
 
@@ -278,9 +326,10 @@ def add_pep725_metadata(metadata: dict, toml_metadata: dict):
         ("run", "dependencies"),
     )
     for conda_section, pep725_section in section_map:
-        requirements[conda_section] = [
+        requirements.setdefault(conda_section, [])
+        requirements[conda_section].extend([
             get_pep725_mapping(purl) for purl in externals.get(pep725_section, [])
-        ]
+        ])
         # TODO: handle optional dependencies properly
         optional_features = toml_metadata.get(f"optional-{pep725_section}", {})
         for feature_name, feature_deps in optional_features.items():

--- a/grayskull/strategy/py_toml.py
+++ b/grayskull/strategy/py_toml.py
@@ -327,9 +327,9 @@ def add_pep725_metadata(metadata: dict, toml_metadata: dict):
     )
     for conda_section, pep725_section in section_map:
         requirements.setdefault(conda_section, [])
-        requirements[conda_section].extend([
-            get_pep725_mapping(purl) for purl in externals.get(pep725_section, [])
-        ])
+        requirements[conda_section].extend(
+            [get_pep725_mapping(purl) for purl in externals.get(pep725_section, [])]
+        )
         # TODO: handle optional dependencies properly
         optional_features = toml_metadata.get(f"optional-{pep725_section}", {})
         for feature_name, feature_deps in optional_features.items():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Add more packages to the conda-mappings in support of PEP 725 (essentially all default dependencies of Sagemath).

Moreover, fix a little bug that `[external]` dependencies would completely overwrite the normal Python dependencies. 

CC @rgommers and @msarahan 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
