### PR TITLE
Add opencv-python-headless to strategy/config.yaml

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -306,6 +306,10 @@ opencv-python:
   import_name: cv2
   conda_forge: opencv
 
+opencv-python-headless:
+  import_name: cv2
+  conda_forge: opencv
+
 ortools:
   conda_forge: ortools-python
   import_name: ortools


### PR DESCRIPTION
### Description

Hello everyone, thanks for the work on grayskull! I am not an expert, but today I tried to grayskull generate the recipe for `idtrackerai`, and this was the result:

~~~
traversaro@IITBMP014LW012:~$ grayskull pypi idtrackerai



#### Initializing recipe for idtrackerai (pypi) ####

Recovering metadata from pypi...
Starting the download of the sdist package idtrackerai
idtrackerai 100% Time:  0:00:03   1.3 MiB/s|##########################################################################|
Checking for pyproject.toml
pyproject.toml found in /tmp/grayskull-idtrackerai-rp_9kl3_/idtrackerai-5.2.7/pyproject.toml
Recovering information from setup.py
Executing injected distutils...
Checking >> matplotlib 100% |##################################################################|[Elapsed Time: 0:00:08]
Matching license file with database from Grayskull...
Match percentage of the license is 96%. Low match percentage could mean that the license was modified.
License type: GPL-3.0
License file: ['LICENSE']
Build requirements:
  <none>
Host requirements:
  - python >=3.10
  - setuptools
  - pip
Run requirements:
  - python >=3.10
  - numpy >=1.24.2
  - rich >=13.3.1
  - h5py >=3.8.0
  - scipy >=1.10.0
  - opencv-python-headless >=4.7.0
  - pyqt >=5.15.9
  - qtpy >=2.3.1
  - superqt >=0.4.1
  - toml >=0.10.2
  - matplotlib-base >=3.7.0

RED: Missing packages
GREEN: Packages available on conda-forge

Maintainers:
   - traversaro

#### Recipe generated on /home/traversaro for idtrackerai ####
~~~

I just realized that colors are not copy&pasted, but basically `opencv-python-headless` is marked as not available. However, I think this is confusing as  `opencv-python-headless` is just a variant with less dependencies of `opencv-python`, but its functionality are a subset of the one of `opencv-python`, so just mapping it to `opencv` conda package seems just the least confusing thing to do. Not sure if modifying `strategy/config.yaml` is the right thing to do. 

See also:
* https://github.com/conda-forge/opencv-feedstock/issues/293#issuecomment-1989457087
* https://github.com/conda-forge/staged-recipes/pull/25669


