### PR TITLE
Fix package name based on local sdist archive

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,9 @@ def data_dir() -> str:
 @fixture(scope="session")
 def pkg_pytest(tmpdir_factory) -> str:
     folder = tmpdir_factory.mktemp("test-download-pkg")
-    dest_pkg = str(folder / "PYTEST-PKG.tar.gz")
+    # Use different package name and version for the sdist archive on purpose
+    # Correct info should be extracted from the metadata and not filename
+    dest_pkg = str(folder / "PYTEST-PKG-1.0.0.tar.gz")
     download_sdist_pkg(
         "https://pypi.io/packages/source/p/pytest/pytest-5.3.5.tar.gz", dest_pkg
     )

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from colorama import Fore, Style
+from souschef.jinja_expression import get_global_jinja_var
 from souschef.recipe import Recipe
 
 from grayskull.base.factory import GrayskullFactory
@@ -1260,6 +1261,8 @@ def test_create_recipe_from_local_sdist(pkg_pytest):
     assert recipe["about"]["summary"] == "pytest: simple powerful testing with Python"
     assert recipe["about"]["license"] == "MIT"
     assert recipe["about"]["license_file"] == "LICENSE"
+    assert get_global_jinja_var(recipe, "name") == "pytest"
+    assert get_global_jinja_var(recipe, "version") == "5.3.5"
 
 
 @patch("grayskull.strategy.py_base.get_all_toml_info", return_value={})


### PR DESCRIPTION
When using a local sdist as source, the package name of the conda recipe was based on the sdist filename.
This used to be the same (at least as far as I know) but since [setuptools 69.3.0](https://github.com/pypa/setuptools/issues/3593), the sdist filename is now normalized.
For example, if a package name contains a dash, it's converted to underscore (for `my-package`, the sdist is now `my_package-1.0.0.tar.gz` instead of `my-package-1.0.0.tar.gz` as before).

The initial package name extracted from the filename has to be overwritten with the name retrieved from the metadata.