### PR TITLE
Starts work on adding recipe upgrade feature

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -29,3 +29,4 @@ dependencies:
   - libcblas
   - beautifulsoup4
   - semver >=3.0.0,<4.0.0
+  # - conda-recipe-manager >=0.2.0

--- a/environment.yaml
+++ b/environment.yaml
@@ -29,4 +29,4 @@ dependencies:
   - libcblas
   - beautifulsoup4
   - semver >=3.0.0,<4.0.0
-  # - conda-recipe-manager >=0.2.0
+  - conda-recipe-manager >=0.2.0

--- a/grayskull/main.py
+++ b/grayskull/main.py
@@ -92,6 +92,15 @@ def init_parser():
         help="If sections are specified, grayskull will populate just the sections "
         "informed.",
     )
+    cran_parser.add_argument(
+        "--use-v1-format",
+        "-u",
+        default=False,
+        action="store_true",
+        dest="use_v1_format",
+        help="Returns a recipe file in the V1 format, used by rattler-build."
+        " NOTE: This is experimental.",
+    )
     # create parser for pypi
     pypi_parser = subparsers.add_parser("pypi", help="Options to generate PyPI recipes")
     pypi_parser.add_argument(
@@ -244,6 +253,15 @@ def init_parser():
         dest="licence_exclude_folders",
         help="Exclude folders when searching for licence.",
     )
+    pypi_parser.add_argument(
+        "--use-v1-format",
+        "-u",
+        default=False,
+        action="store_true",
+        dest="use_v1_format",
+        help="Returns a recipe file in the V1 format, used by rattler-build."
+        " NOTE: This is experimental.",
+    )
 
     return parser
 
@@ -319,7 +337,7 @@ def generate_recipes_from_list(list_pkgs, args):
         if args.sections_populate is None or "extra" in args.sections_populate:
             add_extra_section(recipe, args.maintainers)
 
-        generate_recipe(recipe, config, args.output)
+        generate_recipe(recipe, config, args.output, args.use_v1_format)
         print_msg(
             f"\n{Fore.GREEN}#### Recipe generated on "
             f"{os.path.realpath(args.output)} for {pkg_name} ####\n\n"
@@ -365,7 +383,7 @@ def generate_r_recipes_from_list(list_pkgs, args):
         if args.sections_populate is None or "extra" in args.sections_populate:
             add_extra_section(recipe, args.maintainers)
 
-        generate_recipe(recipe, config, args.output)
+        generate_recipe(recipe, config, args.output, args.use_v1_format)
         print_msg(
             f"\n{Fore.GREEN}#### Recipe generated on "
             f"{os.path.realpath(args.output)} for {pkg_name} ####\n\n"

--- a/grayskull/utils.py
+++ b/grayskull/utils.py
@@ -248,6 +248,7 @@ def upgrade_v0_recipe_to_v1(recipe: Recipe, recipe_path: Path) -> None:
     recipe_content = recipe_stream.getvalue()
     recipe_stream.close()
 
+    recipe_content = RecipeParserConvert.pre_process_recipe_text(recipe_content)
     recipe_converter = RecipeParserConvert(recipe_content)
     v1_content, _, _ = recipe_converter.render_to_v1_recipe_format()
     recipe_path.write_text(v1_content, encoding="utf-8")


### PR DESCRIPTION
### Description
First-pass implementation supporting the V1 recipe standard (used by `rattler-build`, as discussed in #486 

~~As of writing this PR (currently in the `DRAFT` stage), there are a few issues:~~
~~1. `conda-recipe-manager` is not currently in the conda-forge channel. There is an [open PR](https://github.com/conda-forge/staged-recipes/pull/26371) waiting for a review to add it in.
2. Locally, I can't get `ruamel` to dump `souschef`'s version of the recipe data into a `StringIO` stream. I had many issues getting conda to use my local copy of `conda-recipe-manager` and I _think_ it's related to that. I have `ruamel.yaml.jinja` installed in the local environment, but I still get an error. Here are some logs for more details:~~

```sh
(grayskull) smartin@Schuylers-MacBook-Pro:grayskull> grayskull pypi -u types-toml                       



#### Initializing recipe for types-toml (pypi) ####

Recovering metadata from pypi...
Starting the download of the sdist package types-toml
types-toml 100% Time:  0:00:00   1.8 MiB/s|####################################################################################|
Checking for pyproject.toml
pyproject.toml not found.
Recovering information from setup.py
Executing injected distutils...
Recovering metadata from setup.cfg
No data was recovered from setup.py. Forcing to execute the setup.py as script
Recovering metadata from setup.cfg
Checking >> -- 100% |#                                                                                  |[Elapsed Time: 0:00:00]
Recovering license info from spdx.org ...
INFO:Best match for license Apache-2.0 was Apache-2.0.
Best matches: [('Apache-2.0', 100.0, 0), ('Apache-1.0', 90.0, 1), ('Apache-1.1', 80.0, 2), ('Apache License 1.0', 67.5, 4), ('Zend-2.0', 55.55555555555556, 3)]
INFO:Github url: https://api.github.com/repos/python/typeshed/license?ref=0.10.8.20240310 - recovering license info
Recovering license information from github...
Recovering license info from repository...
Cloning into '/var/folders/mj/y6v4_y555yx3_370k4sk0_bh0000gp/T/gs-clone-repo-amc55x71'...
fatal: Remote branch 0.10.8.20240310 not found in upstream origin
Recovering license info from repository...
Cloning into '/var/folders/mj/y6v4_y555yx3_370k4sk0_bh0000gp/T/gs-clone-repo-a_k02yuu'...
fatal: Remote branch v0.10.8.20240310 not found in upstream origin
License type: Apache-2.0
License file: []
Build requirements:
  <none>
Host requirements:
  - python >=3.8
  - pip
Run requirements:
  - python >=3.8

RED: Package names not available on conda-forge
YELLOW: PEP-725 PURLs that did not map to known package
GREEN: Packages available on conda-forge

Maintainers:
   - schuylermartin45
Traceback (most recent call last):
  File "/Users/smartin/miniconda3/envs/grayskull/bin/grayskull", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/smartin/work/grayskull/grayskull/main.py", line 295, in main
    generate_recipes_from_list(args.pypi_packages, args)
  File "/Users/smartin/work/grayskull/grayskull/main.py", line 340, in generate_recipes_from_list
    generate_recipe(recipe, config, args.output, args.use_v1_format)
  File "/Users/smartin/work/grayskull/grayskull/utils.py", line 230, in generate_recipe
    upgrade_v0_recipe_to_v1(recipe, recipe_path)
  File "/Users/smartin/work/grayskull/grayskull/utils.py", line 247, in upgrade_v0_recipe_to_v1
    yaml.dump(recipe.yaml, recipe_stream)
  File "/Users/smartin/miniconda3/envs/grayskull/lib/python3.11/site-packages/ruamel/yaml/main.py", line 574, in dump
    return self.dump_all([data], stream, transform=transform)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smartin/miniconda3/envs/grayskull/lib/python3.11/site-packages/ruamel/yaml/main.py", line 583, in dump_all
    self._context_manager.dump(data)
  File "/Users/smartin/miniconda3/envs/grayskull/lib/python3.11/site-packages/ruamel/yaml/main.py", line 913, in dump
    self.init_output(data)
  File "/Users/smartin/miniconda3/envs/grayskull/lib/python3.11/site-packages/ruamel/yaml/main.py", line 906, in init_output
    self._yaml.get_serializer_representer_emitter(self._output, tlca)
  File "/Users/smartin/miniconda3/envs/grayskull/lib/python3.11/site-packages/ruamel/yaml/main.py", line 644, in get_serializer_representer_emitter
    self.emitter.stream = stream
    ^^^^^^^^^^^^^^^^^^^
  File "/Users/smartin/miniconda3/envs/grayskull/lib/python3.11/site-packages/ruamel/yaml/jinja2/__plug_in__.py", line 88, in stream
    self, Rewriter(val, getattr(self.dumper, '_plug_in_' + typ))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'YAML' object has no attribute '_plug_in_jinja2'
```



<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->



<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->


