### PR TITLE
Generate recipe from project tree using pypa/build

### DIFF
--- a/grayskull/base/factory.py
+++ b/grayskull/base/factory.py
@@ -7,16 +7,21 @@ from souschef.jinja_expression import get_global_jinja_var
 from souschef.recipe import Recipe
 
 from grayskull.strategy.cran import CranStrategy
-from grayskull.strategy.py_build import PyBuild
+try:
+    from grayskull.strategy.py_build import PyBuild
+except ImportError: # requires conda
+    PyBuild = None
 from grayskull.strategy.pypi import PypiStrategy
 
 
 class GrayskullFactory(ABC):
     REGISTERED_STRATEGY = {
         "pypi": PypiStrategy,
-        "pybuild": PyBuild,
         "cran": CranStrategy,
     }
+
+    if PyBuild:
+        REGISTERED_STRATEGY["pybuild"] = PyBuild
 
     @staticmethod
     def create_recipe(repo_type: str, config, pkg_name=None, sections_populate=None):

--- a/grayskull/base/factory.py
+++ b/grayskull/base/factory.py
@@ -7,9 +7,10 @@ from souschef.jinja_expression import get_global_jinja_var
 from souschef.recipe import Recipe
 
 from grayskull.strategy.cran import CranStrategy
+
 try:
     from grayskull.strategy.py_build import PyBuild
-except ImportError: # requires conda
+except ImportError:  # requires conda
     PyBuild = None
 from grayskull.strategy.pypi import PypiStrategy
 

--- a/grayskull/base/factory.py
+++ b/grayskull/base/factory.py
@@ -7,12 +7,14 @@ from souschef.jinja_expression import get_global_jinja_var
 from souschef.recipe import Recipe
 
 from grayskull.strategy.cran import CranStrategy
+from grayskull.strategy.py_build import PyBuild
 from grayskull.strategy.pypi import PypiStrategy
 
 
 class GrayskullFactory(ABC):
     REGISTERED_STRATEGY = {
         "pypi": PypiStrategy,
+        "pybuild": PyBuild,
         "cran": CranStrategy,
     }
 

--- a/grayskull/config.py
+++ b/grayskull/config.py
@@ -42,6 +42,7 @@ class Configuration:
     is_arch: bool = False
     repo_github: Optional[str] = None
     from_local_sdist: bool = False
+    from_tree: bool = False
     local_sdist: Optional[str] = None
     missing_deps: set = field(default_factory=set)
     extras_require_test: Optional[str] = None

--- a/grayskull/license/discovery.py
+++ b/grayskull/license/discovery.py
@@ -62,7 +62,7 @@ def get_all_licenses_from_spdx() -> List:
     ]
 
 
-def _match_scrambled_exact(candidate, licenses) -> str | None:
+def _match_scrambled_exact(candidate, licenses):
     """
     Return license with rearranged word order only.
 
@@ -72,6 +72,7 @@ def _match_scrambled_exact(candidate, licenses) -> str | None:
     for license in licenses:
         if bag == set(re.findall(r"\w+", license.lower())):
             return license
+    return ""
 
 
 def match_license(name: str) -> dict:

--- a/grayskull/license/discovery.py
+++ b/grayskull/license/discovery.py
@@ -62,6 +62,18 @@ def get_all_licenses_from_spdx() -> List:
     ]
 
 
+def _match_scrambled_exact(candidate, licenses) -> str | None:
+    """
+    Return license with rearranged word order only.
+
+    Fancy scorer confuses BSD-3-Clause with DEC-3-Clause.
+    """
+    bag = set(re.findall(r"\w+", candidate.lower()))
+    for license in licenses:
+        if bag == set(re.findall(r"\w+", license.lower())):
+            return license
+
+
 def match_license(name: str) -> dict:
     """Match if the given license name matches any license present on
     spdx.org
@@ -75,11 +87,16 @@ def match_license(name: str) -> dict:
     name = re.sub(r"\s+license\s*", "", name.strip(), flags=re.IGNORECASE)
     name = name.strip()
 
-    best_matches = process.extract(
-        name, _get_all_license_choice(all_licenses), scorer=partial_ratio
-    )
-    best_matches = process.extract(name, [lc for lc, *_ in best_matches])
-    spdx_license = best_matches[0]
+    exact_match = _match_scrambled_exact(name, _get_all_license_choice(all_licenses))
+    if exact_match:
+        best_matches = [(exact_match, 100, 0)]
+        spdx_license = best_matches[0]
+    else:
+        best_matches = process.extract(
+            name, _get_all_license_choice(all_licenses), scorer=partial_ratio
+        )
+        best_matches = process.extract(name, [lc for lc, *_ in best_matches])
+        spdx_license = best_matches[0]
 
     if spdx_license[1] < 100:
         # Prefer "-or-later" licenses over the "-only"

--- a/grayskull/main.py
+++ b/grayskull/main.py
@@ -14,7 +14,12 @@ from grayskull.base.github import get_git_current_user
 from grayskull.cli import CLIConfig
 from grayskull.cli.stdout import print_msg
 from grayskull.config import Configuration
-from grayskull.utils import generate_recipe, origin_is_github, origin_is_local_sdist
+from grayskull.utils import (
+    generate_recipe,
+    origin_is_github,
+    origin_is_local_sdist,
+    origin_is_tree,
+)
 
 init(autoreset=True)
 logging.basicConfig(format="%(levelname)s:%(message)s")
@@ -283,10 +288,13 @@ def generate_recipes_from_list(list_pkgs, args):
     for pkg_name in list_pkgs:
         logging.debug(f"Starting grayskull for pkg: {pkg_name}")
         from_local_sdist = origin_is_local_sdist(pkg_name)
+        from_tree = origin_is_tree(pkg_name)
         if origin_is_github(pkg_name):
             pypi_label = ""
         elif from_local_sdist:
             pypi_label = " (local)"
+        elif from_tree:
+            pypi_label = " (tree)"
         else:
             pypi_label = " (pypi)"
         print_msg(
@@ -304,6 +312,7 @@ def generate_recipes_from_list(list_pkgs, args):
                 url_pypi_metadata=args.url_pypi_metadata,
                 sections_populate=args.sections_populate,
                 from_local_sdist=from_local_sdist,
+                from_tree=from_tree,
                 extras_require_test=args.extras_require_test,
                 github_release_tag=args.github_release_tag,
                 extras_require_include=tuple(args.extras_require_include),
@@ -333,7 +342,9 @@ def create_python_recipe(pkg_name, sections_populate=None, **kwargs):
     config = Configuration(name=pkg_name, **kwargs)
     return (
         GrayskullFactory.create_recipe(
-            "pypi", config, sections_populate=sections_populate
+            "pybuild" if config.from_tree else "pypi",
+            config,
+            sections_populate=sections_populate,
         ),
         config,
     )

--- a/grayskull/strategy/py_build.py
+++ b/grayskull/strategy/py_build.py
@@ -8,13 +8,15 @@ import tempfile
 from importlib.metadata import PathDistribution
 from pathlib import Path
 
-import build
-from packaging.markers import Marker
-from packaging.metadata import Metadata
+from conda.exceptions import InvalidMatchSpec
+from conda.models.match_spec import MatchSpec
+from packaging.requirements import Requirement
 from souschef.recipe import Recipe
 
+import build
 from grayskull.config import Configuration
 from grayskull.strategy.abstract_strategy import AbstractStrategy
+from grayskull.strategy.pypi import compose_test_section
 
 log = logging.getLogger(__name__)
 
@@ -24,16 +26,15 @@ class PyBuild(AbstractStrategy):
     def fetch_data(recipe: Recipe, config: Configuration, sections=None):
         project = build.ProjectBuilder(config.name)
 
+        recipe["source"]["path"] = "../"
+        # XXX relative to output. "git_url: ../" is also a good choice.
+
         with tempfile.TemporaryDirectory(prefix="grayskull") as output:
             build_system_requires = project.build_system_requires
             requires_for_build = project.get_requires_for_build("wheel")
             # If those are already installed, we can get the extras requirements
             # without invoking pip e.g. setuptools_scm[toml]
             print("Requires for build:", build_system_requires, requires_for_build)
-
-            recipe["requirements"]["host"] = sorted(
-                (*build_system_requires, *requires_for_build)
-            )
 
             # build the project's metadata "dist-info" directory
             metadata_path = Path(project.metadata_path(output_directory=output))
@@ -42,23 +43,67 @@ class PyBuild(AbstractStrategy):
 
             # real distribution name not pathname
             config.name = distribution.name  # see also _normalized_name
+            config.version = distribution.version
 
             # grayskull thought the name was the path. correct that.
             if recipe[0] == '#% set name = "." %}':  # XXX fragile
                 # recipe[0] = x does not work
-                recipe._yaml._yaml_get_pre_comment()[
-                    0
-                ].value = f'#% set name = "{config.name}" %}}'
-            elif config.name not in recipe[0]:
+                recipe._yaml._yaml_get_pre_comment()[0].value = (
+                    f'#% set name = "{config.name}" %}}\n'
+                    f'#% set version = "{config.version}" %}}\n'
+                )
+
+                recipe["package"]["version"] = "{{ version }}"
+            elif config.name not in str(recipe[0]):
                 log.warning("Package name not found in first line of recipe")
 
-            config.version = distribution.version
-            requires_dist = (
-                distribution.requires
-            )  # includes extras as markers e.g. ; extra == 'testing'. Evaluate using Marker().
-            entry_points = (
-                distribution.entry_points
-            )  # list(EntryPoint(name, value, group)
+            metadata = distribution.metadata
+
+            requires_python = metadata["requires-python"]
+            if requires_python:
+                requires_python = f"python { requires_python }"
+            else:
+                requires_python = "python"
+
+            recipe["requirements"]["host"] = [requires_python] + sorted(
+                (*build_system_requires, *requires_for_build)
+            )
+
+            requirements = [Requirement(r) for r in distribution.requires]
+            active_requirements = [
+                str(r).rsplit(";", 1)[0]
+                for r in requirements
+                if not r.marker or r.marker.evaluate()
+            ]
+            # XXX to normalize space between name and version, MatchSpec(r).spec
+            normalized_requirements = []
+            for requirement in active_requirements:
+                try:
+                    normalized_requirements.append(
+                        # MatchSpec uses a metaclass hiding its constructor from
+                        # the type checker
+                        MatchSpec(requirement).spec  # type: ignore
+                    )
+                except InvalidMatchSpec:
+                    log.warning("%s is not a valid MatchSpec", requirement)
+                    normalized_requirements.append(requirement)
+
+            # conda does support ~=3.0.0 "compatibility release" matches
+            recipe["requirements"]["run"] = [requires_python] + normalized_requirements
+            # includes extras as markers e.g. ; extra == 'testing'. Evaluate
+            # using Marker().
+
+            recipe["build"]["entry_points"] = [
+                f"{ep.name} = {ep.value}"
+                for ep in distribution.entry_points
+                if ep.group == "console_scripts"
+            ]
+
+            recipe["build"]["noarch"] = "python"
+            recipe["build"][
+                "script"
+            ] = "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+            # XXX also --no-index?
 
             # distribution.metadata.keys() for grayskull is
             # Metadata-Version
@@ -76,5 +121,24 @@ class PyBuild(AbstractStrategy):
             # Requires-Dist (many times)
             # Provides-Extra (several times)
             # Description or distribution.metadata.get_payload()
+
+            about = {
+                "summary": metadata["summary"],
+                "license": metadata["license"],
+                # there are two license-file in grayskull e.g.
+                "license_file": metadata["license-file"],
+            }
+            recipe["about"] = about
+
+            metadata_dict = dict(
+                metadata
+            )  # XXX not what compose_test_section expects at all
+            metadata_dict["name"] = config.name
+            metadata_dict["entry_points"] = [
+                f"{ep.name} = {ep.value}"
+                for ep in distribution.entry_points
+                if ep.group == "console_scripts"
+            ]
+            recipe["test"] = compose_test_section(metadata_dict, [])
 
         # raise NotImplementedError()

--- a/grayskull/strategy/py_build.py
+++ b/grayskull/strategy/py_build.py
@@ -40,6 +40,8 @@ class PyBuild(AbstractStrategy):
             # there a dict API?) Subtract "has non-extra marker" dependencies from
             # this set.
             #
+            # Easier API is deprecated pkg_resources.Distribution().requires(extras=())
+            #
             # for e in scm.metadata.get_all('provides-extra'):
             #   print (e, [x for x in r if x.marker and x.marker.evaluate({'extra':e})])
             #

--- a/grayskull/strategy/py_build.py
+++ b/grayskull/strategy/py_build.py
@@ -8,12 +8,12 @@ import tempfile
 from importlib.metadata import PathDistribution
 from pathlib import Path
 
-import build
 from conda.exceptions import InvalidMatchSpec
 from conda.models.match_spec import MatchSpec
 from packaging.requirements import Requirement
 from souschef.recipe import Recipe
 
+import build
 from grayskull.config import Configuration
 from grayskull.strategy.abstract_strategy import AbstractStrategy
 from grayskull.strategy.pypi import compose_test_section
@@ -35,6 +35,18 @@ class PyBuild(AbstractStrategy):
             # If those are already installed, we can get the extras requirements
             # without invoking pip e.g. setuptools_scm[toml]
             print("Requires for build:", build_system_requires, requires_for_build)
+
+            # Example of finding extra dependencies for a distribution 'scm' (is
+            # there a dict API?) Subtract "has non-extra marker" dependencies from
+            # this set.
+            #
+            # for e in scm.metadata.get_all('provides-extra'):
+            #   print (e, [x for x in r if x.marker and x.marker.evaluate({'extra':e})])
+            #
+            #     docs [<Requirement('entangled-cli[rich]; extra == "docs"')>, <Requirement('mkdocs; extra == "docs"')>, <Requirement('mkdocs-entangled-plugin; extra == "docs"')>, <Requirement('mkdocs-material; extra == "docs"')>, <Requirement('mkdocstrings[python]; extra == "docs"')>, <Requirement('pygments; extra == "docs"')>]
+            #     rich [<Requirement('rich; extra == "rich"')>]
+            #     test [<Requirement('build; extra == "test"')>, <Requirement('pytest; extra == "test"')>, <Requirement('rich; extra == "test"')>, <Requirement('wheel; extra == "test"')>]
+            #     toml []
 
             # build the project's metadata "dist-info" directory
             metadata_path = Path(project.metadata_path(output_directory=output))

--- a/grayskull/strategy/py_build.py
+++ b/grayskull/strategy/py_build.py
@@ -69,7 +69,7 @@ class PyBuild(AbstractStrategy):
                 (*build_system_requires, *requires_for_build)
             )
 
-            requirements = [Requirement(r) for r in distribution.requires]
+            requirements = [Requirement(r) for r in distribution.requires or []]
             active_requirements = [
                 str(r).rsplit(";", 1)[0]
                 for r in requirements
@@ -100,9 +100,9 @@ class PyBuild(AbstractStrategy):
             ]
 
             recipe["build"]["noarch"] = "python"
-            recipe["build"][
-                "script"
-            ] = "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+            recipe["build"]["script"] = (
+                "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+            )
             # XXX also --no-index?
 
             # distribution.metadata.keys() for grayskull is

--- a/grayskull/strategy/py_build.py
+++ b/grayskull/strategy/py_build.py
@@ -8,12 +8,12 @@ import tempfile
 from importlib.metadata import PathDistribution
 from pathlib import Path
 
+import build
 from conda.exceptions import InvalidMatchSpec
 from conda.models.match_spec import MatchSpec
 from packaging.requirements import Requirement
 from souschef.recipe import Recipe
 
-import build
 from grayskull.config import Configuration
 from grayskull.strategy.abstract_strategy import AbstractStrategy
 from grayskull.strategy.pypi import compose_test_section

--- a/grayskull/strategy/py_build.py
+++ b/grayskull/strategy/py_build.py
@@ -3,18 +3,18 @@ Use pypa/build to get project metadata from a checkout. Create a recipe suitable
 for inlinining into the first-party project source tree.
 """
 
+import logging
 import tempfile
 from importlib.metadata import PathDistribution
 from pathlib import Path
 
+import build
 from packaging.markers import Marker
 from packaging.metadata import Metadata
 from souschef.recipe import Recipe
 
-import build
 from grayskull.config import Configuration
 from grayskull.strategy.abstract_strategy import AbstractStrategy
-import logging
 
 log = logging.getLogger(__name__)
 
@@ -53,7 +53,9 @@ class PyBuild(AbstractStrategy):
                 log.warning("Package name not found in first line of recipe")
 
             config.version = distribution.version
-            requires_dist = distribution.requires  # includes extras as markers e.g. ; extra == 'testing'. Evaluate using Marker().
+            requires_dist = (
+                distribution.requires
+            )  # includes extras as markers e.g. ; extra == 'testing'. Evaluate using Marker().
             entry_points = (
                 distribution.entry_points
             )  # list(EntryPoint(name, value, group)

--- a/grayskull/strategy/py_build.py
+++ b/grayskull/strategy/py_build.py
@@ -1,0 +1,78 @@
+"""
+Use pypa/build to get project metadata from a checkout. Create a recipe suitable
+for inlinining into the first-party project source tree.
+"""
+
+import tempfile
+from importlib.metadata import PathDistribution
+from pathlib import Path
+
+from packaging.markers import Marker
+from packaging.metadata import Metadata
+from souschef.recipe import Recipe
+
+import build
+from grayskull.config import Configuration
+from grayskull.strategy.abstract_strategy import AbstractStrategy
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class PyBuild(AbstractStrategy):
+    @staticmethod
+    def fetch_data(recipe: Recipe, config: Configuration, sections=None):
+        project = build.ProjectBuilder(config.name)
+
+        with tempfile.TemporaryDirectory(prefix="grayskull") as output:
+            build_system_requires = project.build_system_requires
+            requires_for_build = project.get_requires_for_build("wheel")
+            # If those are already installed, we can get the extras requirements
+            # without invoking pip e.g. setuptools_scm[toml]
+            print("Requires for build:", build_system_requires, requires_for_build)
+
+            recipe["requirements"]["host"] = sorted(
+                (*build_system_requires, *requires_for_build)
+            )
+
+            # build the project's metadata "dist-info" directory
+            metadata_path = Path(project.metadata_path(output_directory=output))
+
+            distribution = PathDistribution(metadata_path)
+
+            # real distribution name not pathname
+            config.name = distribution.name  # see also _normalized_name
+
+            # grayskull thought the name was the path. correct that.
+            if recipe[0] == '#% set name = "." %}':  # XXX fragile
+                # recipe[0] = x does not work
+                recipe._yaml._yaml_get_pre_comment()[
+                    0
+                ].value = f'#% set name = "{config.name}" %}}'
+            elif config.name not in recipe[0]:
+                log.warning("Package name not found in first line of recipe")
+
+            config.version = distribution.version
+            requires_dist = distribution.requires  # includes extras as markers e.g. ; extra == 'testing'. Evaluate using Marker().
+            entry_points = (
+                distribution.entry_points
+            )  # list(EntryPoint(name, value, group)
+
+            # distribution.metadata.keys() for grayskull is
+            # Metadata-Version
+            # Name
+            # Version
+            # Summary
+            # Author-email
+            # License
+            # Project-URL
+            # Keywords
+            # Requires-Python
+            # Description-Content-Type
+            # License-File
+            # License-File
+            # Requires-Dist (many times)
+            # Provides-Extra (several times)
+            # Description or distribution.metadata.get_payload()
+
+        # raise NotImplementedError()

--- a/grayskull/strategy/py_build.py
+++ b/grayskull/strategy/py_build.py
@@ -100,9 +100,9 @@ class PyBuild(AbstractStrategy):
             ]
 
             recipe["build"]["noarch"] = "python"
-            recipe["build"]["script"] = (
-                "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
-            )
+            recipe["build"][
+                "script"
+            ] = "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
             # XXX also --no-index?
 
             # distribution.metadata.keys() for grayskull is

--- a/grayskull/utils.py
+++ b/grayskull/utils.py
@@ -108,6 +108,12 @@ def origin_is_local_sdist(name: str) -> bool:
     )
 
 
+def origin_is_tree(name: str) -> bool:
+    """Return True if it is a directory"""
+    path = Path(name)
+    return path.is_dir()
+
+
 def sha256_checksum(filename, block_size=65536):
     sha256 = hashlib.sha256()
     with open(filename, "rb") as f:
@@ -214,7 +220,7 @@ def generate_recipe(
         recipe_dir = Path(folder_path) / pkg_name
         logging.debug(f"Generating recipe on: {recipe_dir}")
         if not recipe_dir.is_dir():
-            recipe_dir.mkdir()
+            recipe_dir.mkdir(parents=True)
         recipe_path = recipe_dir / "meta.yaml"
         recipe_folder = recipe_dir
         add_new_lines_after_section(recipe.yaml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,10 @@ docs = [
 
 # both spellings of gray/grey
 [project.scripts]
-grayskull = "grayskull.__main__:main"
-greyskull = "grayskull.__main__:main"
-conda-grayskull = "grayskull.__main__:main"
-conda-greyskull = "grayskull.__main__:main"
+grayskull = "grayskull.main:main"
+greyskull = "grayskull.main:main"
+conda-grayskull = "grayskull.main:main"
+conda-greyskull = "grayskull.main:main"
 
 [project.urls]
 Source = "https://github.com/conda/grayskull"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,12 @@ docs = [
     "mdit-py-plugins>=0.3.0",
 ]
 
+# both spellings of gray/grey
 [project.scripts]
-grayskull = "grayskull.main:main"
-conda-greyskull = "grayskull.main:main"
+grayskull = "grayskull.__main__:main"
+greyskull = "grayskull.__main__:main"
+conda-grayskull = "grayskull.__main__:main"
+conda-greyskull = "grayskull.__main__:main"
 
 [project.urls]
 Source = "https://github.com/conda/grayskull"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
     "beautifulsoup4",
+    "build",                  # conda install python-build
     "colorama",
     "conda-souschef >=2.2.3",
     "packaging >=21.3",
@@ -52,8 +53,6 @@ docs = [
 
 [project.scripts]
 grayskull = "grayskull.main:main"
-greyskull = "grayskull.main:main"
-conda-grayskull = "grayskull.main:main"
 conda-greyskull = "grayskull.main:main"
 
 [project.urls]

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -79,6 +79,7 @@ def test_change_pypi_url(mocker):
         url_pypi_metadata="http://url_pypi.com/abc",
         sections_populate=None,
         from_local_sdist=False,
+        from_tree=False,
         extras_require_test=None,
         github_release_tag=None,
         extras_require_include=tuple(),


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This is the start of something I've wanted: `grayskull pypi .` on a checkout to generate a recipe, suitable for committing to the project tree. Like https://github.com/conda/conda/blob/main/recipe/meta.yaml#L5-L7 where source is "../" or the parent directory of the meta.yaml.

pypa/build gets all project metadata in a standard way, including the build-system requires (setuptools, flit, poetry). If these are not already installed, we should add a "conda install <requirement>" before `project.metadata_path(...)` or bail and let the user install those. We would also change the pip command used in the build: section so that we never accidentally pip install a build requirement.

Remaining to be done, process all possible metadata out of `distribution` and into `recipe`; possibly deal with late "we don't know the package name until after `fetch_data`" more elegantly since this breaks grayskull's current assumptions.

It's also a little awkward that the recipe output dir is always `<given directory>/<project name>`. These would be `<checkout>/conda.recipe/meta.yaml` when included as first-party recipes.

Fix #542 

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
