### PR TITLE
fix license discovery: split at dashes for word-based matching

### DIFF
--- a/grayskull/license/discovery.py
+++ b/grayskull/license/discovery.py
@@ -62,6 +62,16 @@ def get_all_licenses_from_spdx() -> List:
     ]
 
 
+def _replace_dashes(s: str) -> str:
+    """
+    Replace dashes with spaces.
+
+    :param s: string to replace dashes with spaces
+    :return: string with dashes replaced by spaces
+    """
+    return s.replace("-", " ")
+
+
 def match_license(name: str) -> dict:
     """Match if the given license name matches any license present on
     spdx.org
@@ -112,12 +122,21 @@ def match_license(name: str) -> dict:
                 lic[0] for lic in original_matches if lic[1] >= spdx_license[1]
             ]
             if len(best_matches) > 1:
+                # we replace dashes by spaces here to match instances like
+                # "3-Clause BSD" with "BSD-3-Clause" which otherwise would
+                # not work with word-based scores like token_sort_ratio
                 spdx_license = process.extractOne(
-                    name, best_matches, scorer=token_sort_ratio
+                    name,
+                    best_matches,
+                    scorer=token_sort_ratio,
+                    processor=_replace_dashes,
                 )
             if original_matches and original_matches[0][1] < 0.55:
                 spdx_license = process.extractOne(
-                    name, [m[0] for m in original_matches], scorer=token_sort_ratio
+                    name,
+                    [m[0] for m in original_matches],
+                    scorer=token_sort_ratio,
+                    processor=_replace_dashes,
                 )
 
     if spdx_license[1] != 100 and spdx_license[0].startswith("MIT"):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->
      
I noticed the following test is currently failing on main: `license/test_discovery/test_discovery.test_short_license_id` for `("3-Clause BSD License", "BSD-3-Clause")`.

Reason: There is a license called `DEC-3-Clause` which is as similar as `BSD-3-Clause` to `3-Clause BSD License` regarding the similarity measures we currently use. Splitting at dashes is a good way of handling cases correctly in which the license name is given without dashes.

It should be noted that the number of tests is very sparse so there is a possibility of breaking something else with this change. I still think it is safe to proceed since we are only modifying the behavior in situations we are unsure anyway.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
    

### Additional Note
The other tests failing on main are not related to this PR.
