### PR TITLE
Expand out the "compatible release" operator for semver dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "ruamel.yaml >=0.16.10",
     "ruamel.yaml.jinja2",
     "setuptools >=30.3.0",
-    "semver~=3.0.0",
+    "semver >=3.0.0,==3.0.*",
     "stdlib-list",
     "tomli",
     "tomli-w",


### PR DESCRIPTION
Assuming I'm not simply confused...

I find the "compatible release" operator extremely confusing and prefer to be explicit.

Reference: https://peps.python.org/pep-0440/#compatible-release

Note that the [semver pin](https://github.com/conda-forge/grayskull-feedstock/blob/b1203cedd4d56cd59665c114759195cce0ab14d7/recipe/meta.yaml#L47C1-L47C32) on the feedstock is inconsistent.

Also, `pip check` will start to fail once semver v3.1 comes out, so probably we should make a repodata patch.