### PR TITLE
Fix meta.yaml output directory

### DIFF
--- a/grayskull/utils.py
+++ b/grayskull/utils.py
@@ -218,7 +218,9 @@ def generate_recipe(
         logging.debug(f"Generating recipe on: {recipe_dir}")
         if not recipe_dir.is_dir():
             recipe_dir.mkdir()
-        recipe_path = recipe_dir / "recipe.yaml" if use_v1_format else "meta.yaml"
+        recipe_path = (
+            recipe_dir / "recipe.yaml" if use_v1_format else recipe_dir / "meta.yaml"
+        )
         recipe_folder = recipe_dir
         add_new_lines_after_section(recipe.yaml)
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description


A small bug was introduced when [adding v1 format](https://github.com/conda/grayskull/pull/539).
The `meta.yaml` file was always created in the current directory instead of `recipe_dir`.


