### PR TITLE
Retrieve packages from top_level.txt when possible

### DIFF
--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -805,6 +805,16 @@ def get_sdist_metadata(
         for key in ("name", "version", "summary", "author"):
             metadata[key] = getattr(dist, key, None)
 
+    # "packages" refer to the modules you can import
+    # That might be different from the distribution name (PKG-INFO name)
+    # packages can be retrieved from setup.py but is usually not defined
+    # in pyproject.toml
+    # For setuptools, it is possible to get it from top_level.txt
+    if "packages" not in metadata or not metadata["packages"]:
+        top_level = list(Path(temp_folder).rglob("*.egg-info/top_level.txt"))
+        if top_level:
+            metadata["packages"] = top_level[0].read_text().split()
+
     return merge_setup_toml_metadata(metadata, pyproject_metadata)
 
 

--- a/tests/test_py_base.py
+++ b/tests/test_py_base.py
@@ -120,6 +120,38 @@ def test_get_sdist_metadata_toml_files_BLACK():
     ]
 
 
+def test_get_sdist_metadata_packages_top_level():
+    """Check that packages can be retrieved from top_level.txt"""
+    # This package only includes a pyproject.toml (no setup.py)
+    # As setuptools is used, the module name can be retrieved
+    # from top_level.txt in the sdist
+    pkg_name = "tangods-achtung"
+    pkg_name_nor = pkg_name.replace("-", "_")
+    pkg_ver = "0.11.1"
+    sdist_metadata = get_sdist_metadata(
+        f"https://pypi.io/packages/source/t/{pkg_name}/{pkg_name_nor}-{pkg_ver}.tar.gz",
+        Configuration(name=pkg_name, version=pkg_ver),
+    )
+    assert sdist_metadata["name"] == pkg_name
+    assert sdist_metadata["packages"] == ["achtung"]
+
+
+def test_get_sdist_metadata_no_top_level():
+    """Regression test when top_level.txt doesn't exist"""
+    # This package only includes a pyproject.toml (no setup.py)
+    # As hatchling is used, there is no top_level.txt file
+    pkg_name = "gidgetlab-kit"
+    pkg_name_nor = pkg_name.replace("-", "_")
+    pkg_ver = "0.7.2"
+    sdist_metadata = get_sdist_metadata(
+        f"https://pypi.io/packages/source/g/{pkg_name}/{pkg_name_nor}-{pkg_ver}.tar.gz",
+        Configuration(name=pkg_name, version=pkg_ver),
+    )
+    assert sdist_metadata["name"] == pkg_name
+    # No solution to retrieve packages for now
+    assert sdist_metadata.get("packages") is None
+
+
 def test_split_deps_without_comma():
     assert split_deps(">=1.8.0<3.0.0,!=2.0.1") == [">=1.8.0", "<3.0.0", "!=2.0.1"]
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The "packages" key that contains the list of modules part of the distribution is used in the test imports section of the conda recipe.
When "packages" isn't present, grayskull will use the name of the distribution, but that might differ.

`packages` isn't part of `PKG-INFO` metadata.
It can be retrieved from `setup.py`.
But when only `pyproject.toml` is present, this is usually not defined. Some info can be added but depends on the build backend.

For project using setuptools, `packages` can be retrieved from the `top_level.txt` file created in the `.egg.info` directory.

For other build backends, I don't have a solution.

