### PR TITLE
Replace remaining pypi.io with pypi.org

### DIFF
--- a/tests/test_py_base.py
+++ b/tests/test_py_base.py
@@ -125,14 +125,14 @@ def test_get_sdist_metadata_packages_top_level():
     # This package only includes a pyproject.toml (no setup.py)
     # As setuptools is used, the module name can be retrieved
     # from top_level.txt in the sdist
-    pkg_name = "tangods-achtung"
-    pkg_name_nor = pkg_name.replace("-", "_")
+    name = "tangods-achtung"
+    name_nor = name.replace("-", "_")
     pkg_ver = "0.11.1"
     sdist_metadata = get_sdist_metadata(
-        f"https://pypi.io/packages/source/t/{pkg_name}/{pkg_name_nor}-{pkg_ver}.tar.gz",
-        Configuration(name=pkg_name, version=pkg_ver),
+        f"https://pypi.org/packages/source/t/{name}/{name_nor}-{pkg_ver}.tar.gz",
+        Configuration(name=name, version=pkg_ver),
     )
-    assert sdist_metadata["name"] == pkg_name
+    assert sdist_metadata["name"] == name
     assert sdist_metadata["packages"] == ["achtung"]
 
 
@@ -140,14 +140,14 @@ def test_get_sdist_metadata_no_top_level():
     """Regression test when top_level.txt doesn't exist"""
     # This package only includes a pyproject.toml (no setup.py)
     # As hatchling is used, there is no top_level.txt file
-    pkg_name = "gidgetlab-kit"
-    pkg_name_nor = pkg_name.replace("-", "_")
+    name = "gidgetlab-kit"
+    name_nor = name.replace("-", "_")
     pkg_ver = "0.7.2"
     sdist_metadata = get_sdist_metadata(
-        f"https://pypi.io/packages/source/g/{pkg_name}/{pkg_name_nor}-{pkg_ver}.tar.gz",
-        Configuration(name=pkg_name, version=pkg_ver),
+        f"https://pypi.org/packages/source/g/{name}/{name_nor}-{pkg_ver}.tar.gz",
+        Configuration(name=name, version=pkg_ver),
     )
-    assert sdist_metadata["name"] == pkg_name
+    assert sdist_metadata["name"] == name
     # No solution to retrieve packages for now
     assert sdist_metadata.get("packages") is None
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Official domain is `pypi.org`. `pypi.io` was a temporary domain that still redirects to `pypi.org`.

Update for created recipe was already done in https://github.com/conda/grayskull/pull/540

I changed more occurrences in the code in https://github.com/conda/grayskull/pull/552 but introduced 2 new pypi.io in https://github.com/conda/grayskull/pull/551

All occurrences should be replaced now.

Also changed some variable names to make flake8 happy about line length. As black is used, shouldn't this rule be disabled?