### PR TITLE
Switch to Ruff tools, update pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length=88
-extend-ignore=E203,D104,D100,I004
-exclude=tests/data/*

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,0 @@
-[settings]
-line_length=88
-known_third_party=requests,ruamel,yaml,pytest,rapidfuzz,opensource,colorama,progressbar,progressbar2
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,19 @@
 exclude: docs
 repos:
--   repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-    -   id: black
-        args: [--safe, --quiet]
--   repo: https://github.com/asottile/blacken-docs
+-   repo: https://github.com/adamchainz/blacken-docs
     rev: 1.18.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==22.6.0]
+        additional_dependencies: [black==22.12.0]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
-    -   id: fix-encoding-pragma
-        args: [--remove]
     -   id: check-yaml
         exclude: tests
     -   id: sort-simple-yaml
-        files: grayskull/pypi/config.yaml
+        files: config.yaml
     -   id: check-toml
     -   id: check-json
     -   id: check-merge-conflict
@@ -28,14 +21,11 @@ repos:
         args: [--autofix]
     -   id: debug-statements
         language_version: python3
--   repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.4
     hooks:
-        -   id: isort
-            exclude: tests/data
--   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-    -   id: flake8
-        exclude: tests/data
-        language_version: python3
+      # Run the linter
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,6 @@ repos:
     hooks:
       # Run the linter
       - id: ruff
-        args: [ --fix ]
+        args: [ --fix, --exit-non-zero-on-fix ]
       # Run the formatter
       - id: ruff-format

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,9 +7,7 @@ exclude .github
 exclude azure-pipelines.yml
 exclude .gitignore
 exclude .pre-commit-config.yaml
-exclude .flake8
 exclude .coveragerc
-exclude .isort.cfg
 prune tests/
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/grayskull/base/track_packages.py
+++ b/grayskull/base/track_packages.py
@@ -53,7 +53,7 @@ def solve_pkg_name(pkg: str, config_file: Union[Path, str]) -> str:
 @lru_cache(maxsize=5)
 def _get_track_info_from_file(config_file: Union[Path, str]) -> Dict:
     yaml = YAML()
-    with open(config_file, "r", encoding="utf_8") as yaml_file:
+    with open(config_file, encoding="utf_8") as yaml_file:
         return yaml.load(yaml_file)
 
 

--- a/grayskull/cli/stdout.py
+++ b/grayskull/cli/stdout.py
@@ -112,10 +112,8 @@ def print_requirements(
         f"\n{Fore.RED}RED{Style.RESET_ALL}: Package names not available on conda-forge"
     )
     print_msg(
-        (
-            f"{Fore.YELLOW}YELLOW{Style.RESET_ALL}: "
-            "PEP-725 PURLs that did not map to known package"
-        )
+        f"{Fore.YELLOW}YELLOW{Style.RESET_ALL}: "
+        "PEP-725 PURLs that did not map to known package"
     )
     print_msg(f"{Fore.GREEN}GREEN{Style.RESET_ALL}: Packages available on conda-forge")
 

--- a/grayskull/license/data/__init__.py
+++ b/grayskull/license/data/__init__.py
@@ -11,6 +11,6 @@ def get_all_licenses() -> List:
         full_path = os.path.join(data_folder, license_file)
         if not os.path.isfile(full_path) or license_file.endswith(".py"):
             continue
-        with open(full_path, "r") as f:
+        with open(full_path) as f:
             all_licenses.append((license_file, f.read()))
     return all_licenses

--- a/grayskull/license/discovery.py
+++ b/grayskull/license/discovery.py
@@ -208,7 +208,7 @@ def get_opensource_license(license_spdx: str) -> dict:
 
 
 def read_licence_cache():
-    with open(Path(__file__).parent / "licence_cache.json", "r") as licence_cache:
+    with open(Path(__file__).parent / "licence_cache.json") as licence_cache:
         return json.load(licence_cache)
 
 
@@ -421,7 +421,7 @@ def get_license_type(path_license: str, default: Optional[str] = None) -> Option
     :param default: Default value for the license type
     :return: License type
     """
-    with open(path_license, "r", errors="ignore") as license_file:
+    with open(path_license, errors="ignore") as license_file:
         license_content = license_file.read()
     find_apache = re.findall(
         r"apache\.org\/licenses\/LICENSE\-([0-9])\.([0-9])",

--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -1,11 +1,3 @@
-art:
-  conda_forge: ascii-art
-  import_name: art
-
-bilby-pipe:
-  conda_forge: bilby_pipe
-  import_name: bilby_pipe
-
 Boruta:
   conda_forge: boruta_py
   import_name: boruta
@@ -30,6 +22,10 @@ annoy:
   conda_forge: python-annoy
   import_name: annoy
 
+art:
+  conda_forge: ascii-art
+  import_name: art
+
 asana:
   conda_forge: python-asana
   import_name: asana
@@ -41,6 +37,14 @@ backtrace:
 bash_completion:
   conda_forge: py-bash-completion
   import_name: bash_completion
+
+bilby-pipe:
+  conda_forge: bilby_pipe
+  import_name: bilby_pipe
+
+blis:
+  conda_forge: cython-blis
+  import_name: blis
 
 build:
   conda_forge: python-build
@@ -102,6 +106,11 @@ data-morph-ai:
   conda_forge: data-morph-ai
   import_name: data_morph
 
+dataclasses:
+  conda_forge: dataclasses
+  import_name: dataclasses
+  avoid_selector: true
+
 datadotworld:
   conda_forge: datadotworld-py
   import_name: datadotworld
@@ -138,6 +147,11 @@ empyrical_dist:
   conda_forge: empyrical-dist
   import_name: empyrical_dist
 
+enum34:
+  conda_forge: enum34
+  import_name: enum
+  avoid_selector: true
+
 esprima:
   conda_forge: esprima-python
   import_name: esprima
@@ -149,6 +163,11 @@ et_xmlfile:
 evalml:
   conda_forge: evaml-core
   import_name: evalml
+
+exceptiongroup:
+  conda_forge: exceptiongroup
+  import_name: exceptiongroup
+  avoid_selector: true
 
 extract-msg:
   conda_forge: msg-extractor
@@ -174,21 +193,29 @@ flex:
   conda_forge: flex-swagger
   import_name: flex
 
+flit_core:
+  conda_forge: flit-core
+  import_name: flit-core
+
 gnupg:
   conda_forge: gnupg-py
   import_name: gnupg
-
-google:
-  conda_forge: googlesearch
-  import_name: googlesearch
 
 google-cloud-bigquery:
   conda_forge: google-cloud-bigquery-core
   import_name: google.cloud.bigquery
 
+google:
+  conda_forge: googlesearch
+  import_name: googlesearch
+
 graphviz:
   import_name: graphviz
   conda_forge: python-graphviz
+
+gssapi:
+  conda_forge: python-gssapi
+  import_name: gssapi
 
 h2o:
   conda_forge: h2o-py
@@ -218,6 +245,16 @@ ib_insync:
   conda_forge: ib-insync
   import_name: ib_insync
 
+import_metadata:
+  conda_forge: import_metadata
+  import_name: import_metadata
+  avoid_selector: true
+
+importlib_metadata:
+  conda_forge: importlib-metadata
+  import_name: importlib-metadata
+  avoid_selector: true
+
 installer:
   conda_forge: python-installer
   import_name: installer
@@ -234,6 +271,14 @@ ioos_tools:
   conda_forge: ioos-tools
   import_name: ioos_tools
 
+jsii:
+  conda_forge: python-jsii
+  import_name: jsii
+
+jupyter-client:
+  conda_forge: jupyter_client
+  import_name: jupyter_client
+
 jupyter_jaeger:
   conda_forge: jupyter-jaeger
   import_name: jupyter_jaeger
@@ -245,6 +290,10 @@ jupyterlab_git:
 jupyterlab_latex:
   conda_forge: jupyterlab-latex
   import_name: jupyterlab_latex
+
+kaleido:
+  conda_forge: python-kaleido
+  import_name: kaleido
 
 kubernetes:
   conda_forge: python-kubernetes
@@ -282,13 +331,13 @@ ndarray_listener:
   conda_forge: ndarray-listener
   import_name: ndarray_listener
 
-neo:
-  conda_forge: python-neo
-  import_name: neo
-
 neo4j:
   conda_forge: neo4j-python-driver
   import_name: neo4j
+
+neo:
+  conda_forge: python-neo
+  import_name: neo
 
 nest_asyncio:
   conda_forge: nest-asyncio
@@ -302,11 +351,11 @@ nvidia-ml-py3:
   conda_forge: nvidia-ml
   import_name: pynvml
 
-opencv-python:
+opencv-python-headless:
   import_name: cv2
   conda_forge: opencv
 
-opencv-python-headless:
+opencv-python:
   import_name: cv2
   conda_forge: opencv
 
@@ -382,9 +431,10 @@ python-qnotifications:
   conda_forge: qnotifications
   import_name: QNotifications
 
-symengine:
-  conda_forge: python-symengine
-  import_name: symengine
+pywin32:
+  conda_forge: pywin32-on-windows
+  import_name: pywin
+  avoid_selector: true
 
 quantum-grove:
   conda_forge: grove
@@ -418,6 +468,10 @@ scikit-build:
   conda_forge: scikit-build
   import_name: skbuild
 
+scikit-learn:
+  conda_forge: scikit-learn
+  import_name: sklearn
+
 setuptools_scm:
   conda_forge: setuptools-scm
   import_name: setuptools_scm
@@ -437,6 +491,10 @@ sphinx-rtd-theme:
 stjudecloud-oliver:
   conda_forge: oliver
   import_name: oliver
+
+symengine:
+  conda_forge: python-symengine
+  import_name: symengine
 
 tables:
   import_name: pytables
@@ -458,6 +516,11 @@ trino:
   conda_forge: trino-python-client
   import_name: trino
 
+typing:
+  conda_forge: typing
+  import_name: typing
+  avoid_selector: true
+
 useDAVE:
   conda_forge: dave
   import_name: numpy
@@ -469,66 +532,3 @@ vsts:
 xxhash:
   import_name: xxhash
   conda_forge: python-xxhash
-
-kaleido:
-  conda_forge: python-kaleido
-  import_name: kaleido
-
-dataclasses:
-  conda_forge: dataclasses
-  import_name: dataclasses
-  avoid_selector: true
-
-typing:
-  conda_forge: typing
-  import_name: typing
-  avoid_selector: true
-
-import_metadata:
-  conda_forge: import_metadata
-  import_name: import_metadata
-  avoid_selector: true
-
-enum34:
-  conda_forge: enum34
-  import_name: enum
-  avoid_selector: true
-
-pywin32:
-  conda_forge: pywin32-on-windows
-  import_name: pywin
-  avoid_selector: true
-
-exceptiongroup:
-  conda_forge: exceptiongroup
-  import_name: exceptiongroup
-  avoid_selector: true
-
-scikit-learn:
-  conda_forge: scikit-learn
-  import_name: sklearn
-
-importlib_metadata:
-  conda_forge: importlib-metadata
-  import_name: importlib-metadata
-  avoid_selector: true
-
-jupyter-client:
-  conda_forge: jupyter_client
-  import_name: jupyter_client
-
-flit_core:
-  conda_forge: flit-core
-  import_name: flit-core
-
-gssapi:
-  conda_forge: python-gssapi
-  import_name: gssapi
-
-jsii:
-  conda_forge: python-jsii
-  import_name: jsii
-
-blis:
-  conda_forge: cython-blis
-  import_name: blis

--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -568,7 +568,7 @@ def discover_license(metadata: dict) -> List[ShortLicense]:
     if not git_url and urlparse(project_url).netloc == "github.com":
         git_url = project_url
     # "url" is always present but sometimes set to None
-    if not git_url and urlparse((metadata.get("url") or "")).netloc == "github.com":
+    if not git_url and urlparse(metadata.get("url") or "").netloc == "github.com":
         git_url = metadata.get("url")
 
     return search_license_file(

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -61,9 +61,9 @@ class PypiStrategy(AbstractStrategy):
     def fetch_data(recipe, config, sections=None):
         update_recipe(recipe, config, sections or ALL_SECTIONS)
         if not (recipe["build"] and recipe["build"]["script"]):
-            recipe["build"][
-                "script"
-            ] = "<{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+            recipe["build"]["script"] = (
+                "<{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+            )
 
 
 def merge_pypi_sdist_metadata(

--- a/grayskull/utils.py
+++ b/grayskull/utils.py
@@ -60,7 +60,7 @@ def get_all_modules_imported_script(script_file: str) -> set:
     node_iter = ast.NodeVisitor()
     node_iter.visit_Import = visit_Import
     node_iter.visit_ImportFrom = visit_ImportFrom
-    with open(script_file, "r") as f:
+    with open(script_file) as f:
         node_iter.visit(ast.parse(f.read()))
     return modules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,21 +65,13 @@ include = ["grayskull", "grayskull.*"]
 [tool.setuptools_scm]
 write_to = "grayskull/_version.py"
 
-[tool.black]
-target-version = ["py310"]
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | \.pytest_cache
-  | _build
-  | buck-out
-  | build
-  | dist
-  | tests/data
-)/
-'''
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle
+    "F",  # Pyflakes
+    "UP",  # pyupgrade
+    "I",  # isort
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/data/**" = ["E", "F"]

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -41,7 +41,7 @@ def test_grayskull_without_options(capsys, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["foo"])
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         cli.main([])
-    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.type is SystemExit
     captured = capsys.readouterr()
     assert "Grayskull - Conda recipe generator" in captured.out
 

--- a/tests/license/test_discovery.py
+++ b/tests/license/test_discovery.py
@@ -111,7 +111,7 @@ def test_search_license_api_github(license_pytest_5_3_1: str):
     assert license_api.name == "MIT"
     assert license_api.path.endswith("LICENSE")
 
-    with open(license_api.path, "r") as f:
+    with open(license_api.path) as f:
         assert f.read() == license_pytest_5_3_1
 
 

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -1050,7 +1050,7 @@ def test_panel_entry_points(tmpdir):
     recipe = GrayskullFactory.create_recipe("pypi", config)
     generate_recipe(recipe, config, folder_path=str(tmpdir))
     recipe_path = str(tmpdir / "panel" / "meta.yaml")
-    with open(recipe_path, "r") as f:
+    with open(recipe_path) as f:
         content = f.read()
     assert "- panel = panel.cli:main" in content
 


### PR DESCRIPTION
The aims of this PR are to switch to faster/modern Ruff-based lint and formatting tools, and to update the pre-commit workflow. Details:

- Replace "black", "isort" and "flake8" with [Ruff](https://docs.astral.sh/ruff/). Some of these rules are selected in pyproject.toml, and I think most others are enabled by default. But keep blacken-docs for now, with the black version updated.
- Remove unused configuration files (and references in MANIFEST.in)
- Remove [deprecated `fix-encoding-pragma`](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#fix-encoding-pragma) which is replaced by pyupgrade/["UP"](https://docs.astral.sh/ruff/rules/#pyupgrade-up) Ruff rule. Other changes from this rule are removing default "r" from open() statements
- Update sort-simple-yaml to look for any "config.yaml" file (there wasn't any grayskull/pypi/config.yaml file). The change from this sorts keys in grayskull/strategy/config.yaml
