### PR TITLE
Handle or operator in Poetry dependency specification

### DIFF
--- a/grayskull/strategy/parse_poetry_version.py
+++ b/grayskull/strategy/parse_poetry_version.py
@@ -194,7 +194,22 @@ def encode_poetry_version(poetry_specifier: str) -> str:
     '>=1.2.0,<1.3.0'
     >>> encode_poetry_version("~1.2.3")
     '>=1.2.3,<1.3.0'
+
+    # handle or operator correctly
+    >>> encode_poetry_version("1.2.3|1.2.4")
+    '1.2.3|1.2.4'
+    >>> encode_poetry_version("^5|| ^6 | ^7")
+    '>=5.0.0,<6.0.0|>=6.0.0,<7.0.0|>=7.0.0,<8.0.0'
     """
+    if "|" in poetry_specifier:
+        poetry_or_clauses = [clause.strip() for clause in poetry_specifier.split("|")]
+        conda_or_clauses = [
+            encode_poetry_version(clause)
+            for clause in poetry_or_clauses
+            if clause != ""
+        ]
+        return "|".join(conda_or_clauses)
+
     poetry_clauses = poetry_specifier.split(",")
 
     conda_clauses = []


### PR DESCRIPTION
### Description

It's not documented in Poetry's [dependency specification](https://python-poetry.org/docs/dependency-specification/) but they support an [or operator](https://github.com/python-poetry/poetry-core/blob/2cbe240beda1bb20eaf02a1ca0353b0ce6c167e6/src/poetry/core/constraints/generic/parser.py#L35).

I ran into this in the wild [here](https://github.com/jerry-git/pytest-split/blob/9cfb51f3bfb33fb10ee344f30292aea0f2705852/pyproject.toml#L37).

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
