### PR TITLE
Ensure local_sdist recipes use a valid URI for the source URL

### DIFF
--- a/grayskull/strategy/py_base.py
+++ b/grayskull/strategy/py_base.py
@@ -794,7 +794,7 @@ def get_sdist_metadata(
         metadata["source"] = {"url": sdist_url, "sha256": sha256_checksum(path_pkg)}
     if config.from_local_sdist:
         metadata["source"] = {
-            "url": f"file://{path_pkg}",
+            "url": Path(path_pkg).as_uri(),
             "sha256": sha256_checksum(path_pkg),
         }
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fixes #448 

Hard-coded URI conversion in the pypi strategy is not valid for local sdist recipes on windows.
This uses `Path().as_uri()` to convert the provided path to the sdist tarball into the proper, machine-dependent URI.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
