### PR TITLE
MNT: Remove 'pip install' options in recipes

### DIFF
--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -64,9 +64,7 @@ class PypiStrategy(AbstractStrategy):
     def fetch_data(recipe, config, sections=None):
         update_recipe(recipe, config, sections or ALL_SECTIONS)
         if not (recipe["build"] and recipe["build"]["script"]):
-            recipe["build"]["script"] = (
-                "<{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
-            )
+            recipe["build"]["script"] = "<{ PYTHON }} -m pip install . -vv"
 
 
 def merge_pypi_sdist_metadata(

--- a/tests/data/poetry/langchain-expected.yaml
+++ b/tests/data/poetry/langchain-expected.yaml
@@ -12,7 +12,7 @@ build:
   entry_points:
     - langchain-server = langchain.server:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:


### PR DESCRIPTION
Resolves #582

### Description

* Remove `--no-deps --no-build-isolation` `pip install` options in recipes as the build tool (e.g. `conda-build`, `rattler-build`) will enforce all required `pip install` options itself at build time.

c.f.:
* https://github.com/conda/conda-build/pull/5541
* https://github.com/prefix-dev/rattler-build/pull/1198

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
