### PR TITLE
Remove one layer of indirection in pypi generated recipes

### DIFF
--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -330,7 +330,7 @@ def get_pypi_metadata(config: Configuration) -> PypiMetadata:
         license=info.get("license"),
         source=SourceSection(
             url=config.url_pypi
-            + "/packages/source/{{ name[0] }}/{{ name }}/"
+            + f"/packages/source/{config.name[0]}/{config.name}/"
             + get_url_filename(metadata),
             sha256=get_sha256_from_pypi_metadata(metadata),
         ),


### PR DESCRIPTION
### Description

`{{ name[0] }}/{{ name }}` is uncessary and adds to cognitive load.

Thanks for considering.
