### PR TITLE
Treat SSL errors as not available

### DIFF
--- a/grayskull/base/pkg_info.py
+++ b/grayskull/base/pkg_info.py
@@ -13,7 +13,8 @@ def is_pkg_available(pkg_name: str, channel: str = "conda-forge") -> bool:
     """
     try:
         response = requests.get(
-            url=f"https://anaconda.org/{channel}/{pkg_name}/files", allow_redirects=False
+            url=f"https://anaconda.org/{channel}/{pkg_name}/files",
+            allow_redirects=False,
         )
     except requests.exceptions.SSLError:
         return False

--- a/grayskull/base/pkg_info.py
+++ b/grayskull/base/pkg_info.py
@@ -11,9 +11,12 @@ def is_pkg_available(pkg_name: str, channel: str = "conda-forge") -> bool:
     :param channel: Anaconda channel
     :return: Return True if the package is present on the given channel
     """
-    response = requests.get(
-        url=f"https://anaconda.org/{channel}/{pkg_name}/files", allow_redirects=False
-    )
+    try:
+        response = requests.get(
+            url=f"https://anaconda.org/{channel}/{pkg_name}/files", allow_redirects=False
+        )
+    except requests.exceptions.SSLError:
+        return False
     return response.status_code == 200
 
 


### PR DESCRIPTION
SSL errors might occur due to firewall issues. So just assume it's not available, since it only drives the CLI output.

It would be better to be able to check against a different repository, such as prefix.dev, but they aren't guaranteed to use the same format URLs when just checking whether there are any packages with the same name.