### PR TITLE
add custom index arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,24 @@ grayskull pypi --pypi-mirror-url https://pypi.example.com --pypi-metadata-url ht
 
 > *Note:* `--pypi-metadata-url` is a replacement for `--pypi-url`; `--pypi-url` is deprecated and will be removed in a future release.
 
+### Checking package availability against custom indexes
+
+By default, Grayskull checks if packages are available on conda-forge and highlights missing dependencies. You can specify custom package indexes to check against using the `--package-indexes` argument:
+
+```bash
+grayskull pypi --package-indexes my-channel company-channel conda-forge pytest
+```
+
+This will check if packages exist in `my-channel`, `company-channel`, or `conda-forge` (in that order) and mark them accordingly in the output.
+
+You can also specify full URLs for internal package indexes that don't use anaconda.org:
+
+```bash
+grayskull pypi --package-indexes https://internal-conda.example.com https://another-index.example.com conda-forge pytest
+```
+
+This is particularly useful for internal networks that don't have access to anaconda.org.
+
 ### Online Grayskull
 
 It is also possible to use Grayskull without any installation. You can go to this website [marcelotrevisani.com/grayskull](https://www.marcelotrevisani.com/grayskull) and inform the name and the version (optional) of the package and it will create the recipe for you.

--- a/README.md
+++ b/README.md
@@ -110,10 +110,18 @@ This will check if packages exist in `my-channel`, `company-channel`, or `conda-
 You can also specify full URLs for internal package indexes that don't use anaconda.org:
 
 ```bash
-grayskull pypi --package-indexes https://internal-conda.example.com https://another-index.example.com conda-forge pytest
+grayskull pypi --package-indexes https://internal-conda.example.com http://another-conda.example.com conda-forge pytest
 ```
 
-This is particularly useful for internal networks that don't have access to anaconda.org.
+Both HTTP and HTTPS protocols are supported for custom package indexes. This is particularly useful for internal networks that don't have access to anaconda.org.
+
+For internal package indexes with custom API structures, you can use the `{pkg_name}` placeholder in your URL:
+
+```bash
+grayskull pypi --package-indexes "https://internal-conda.example.com/api/{pkg_name}/available" conda-forge pytest
+```
+
+This allows you to specify exactly how your internal package index API works, rather than using the default `/pkg_name/files` path structure.
 
 ### Online Grayskull
 

--- a/grayskull/base/pkg_info.py
+++ b/grayskull/base/pkg_info.py
@@ -1,24 +1,38 @@
 from functools import lru_cache
-
+import re
 import requests
+
+from grayskull.cli import CLIConfig
 
 
 @lru_cache(maxsize=35)
-def is_pkg_available(pkg_name: str, channel: str = "conda-forge") -> bool:
-    """Verify if the package is available on Anaconda for a specific channel.
+def is_pkg_available(pkg_name: str, channel: str = None) -> bool:
+    """Verify if the package is available on Anaconda or custom package indexes.
 
     :param pkg_name: Package name
-    :param channel: Anaconda channel
-    :return: Return True if the package is present on the given channel
+    :param channel: Anaconda channel or full URL (if None, will use channels from CLIConfig)
+    :return: Return True if the package is present on any of the given channels or URLs
     """
-    try:
-        response = requests.get(
-            url=f"https://anaconda.org/{channel}/{pkg_name}/files",
-            allow_redirects=False,
-        )
-    except requests.exceptions.SSLError:
-        return False
-    return response.status_code == 200
+    channels_to_check = [channel] if channel else CLIConfig().package_indexes
+    
+    for channel_to_check in channels_to_check:
+        try:
+            # Check if the channel is a full URL
+            if re.match(r'^https?://', channel_to_check):
+                url = f"{channel_to_check.rstrip('/')}/{pkg_name}/files"
+            else:
+                # Default to anaconda.org if not a full URL
+                url = f"https://anaconda.org/{channel_to_check}/{pkg_name}/files"
+                
+            response = requests.get(
+                url=url,
+                allow_redirects=False,
+            )
+            if response.status_code == 200:
+                return True
+        except requests.exceptions.RequestException:
+            continue
+    return False
 
 
 def normalize_pkg_name(pkg_name: str) -> str:

--- a/grayskull/base/pkg_info.py
+++ b/grayskull/base/pkg_info.py
@@ -1,8 +1,24 @@
-from functools import lru_cache
 import re
+from functools import lru_cache
+
 import requests
 
 from grayskull.cli import CLIConfig
+
+
+def build_package_url(channel_or_url: str, pkg_name: str) -> str:
+    """Build the URL to check for package availability.
+
+    :param channel_or_url: Channel name or full URL
+    :param pkg_name: Package name
+    :return: Full URL to check for package availability
+    """
+    # Check if the channel is a full URL
+    if re.match(r"^https?://", channel_or_url):
+        return f"{channel_or_url.rstrip('/')}/{pkg_name}/files"
+    else:
+        # Default to anaconda.org if not a full URL
+        return f"https://anaconda.org/{channel_or_url}/{pkg_name}/files"
 
 
 @lru_cache(maxsize=35)
@@ -10,20 +26,15 @@ def is_pkg_available(pkg_name: str, channel: str = None) -> bool:
     """Verify if the package is available on Anaconda or custom package indexes.
 
     :param pkg_name: Package name
-    :param channel: Anaconda channel or full URL (if None, will use channels from CLIConfig)
+    :param channel: Anaconda channel
+        or full URL (if None, will use channels from CLIConfig)
     :return: Return True if the package is present on any of the given channels or URLs
     """
     channels_to_check = [channel] if channel else CLIConfig().package_indexes
-    
+
     for channel_to_check in channels_to_check:
         try:
-            # Check if the channel is a full URL
-            if re.match(r'^https?://', channel_to_check):
-                url = f"{channel_to_check.rstrip('/')}/{pkg_name}/files"
-            else:
-                # Default to anaconda.org if not a full URL
-                url = f"https://anaconda.org/{channel_to_check}/{pkg_name}/files"
-                
+            url = build_package_url(channel_to_check, pkg_name)
             response = requests.get(
                 url=url,
                 allow_redirects=False,

--- a/grayskull/cli/__init__.py
+++ b/grayskull/cli/__init__.py
@@ -20,7 +20,12 @@ WIDGET_BAR_DOWNLOAD = [
 class CLIConfig:
     __instance: Self | None = None
 
-    def __new__(cls, stdout: bool = False, list_missing_deps: bool = False, package_indexes: list[str] = None):
+    def __new__(
+        cls,
+        stdout: bool = False,
+        list_missing_deps: bool = False,
+        package_indexes: list[str] = None,
+    ):
         if CLIConfig.__instance is None:
             CLIConfig.__instance = object.__new__(cls)
             CLIConfig.__instance.stdout = stdout

--- a/grayskull/cli/__init__.py
+++ b/grayskull/cli/__init__.py
@@ -20,9 +20,10 @@ WIDGET_BAR_DOWNLOAD = [
 class CLIConfig:
     __instance: Self | None = None
 
-    def __new__(cls, stdout: bool = False, list_missing_deps: bool = False):
+    def __new__(cls, stdout: bool = False, list_missing_deps: bool = False, package_indexes: list[str] = None):
         if CLIConfig.__instance is None:
             CLIConfig.__instance = object.__new__(cls)
             CLIConfig.__instance.stdout = stdout
             CLIConfig.__instance.list_missing_deps = list_missing_deps
+            CLIConfig.__instance.package_indexes = package_indexes or ["conda-forge"]
         return CLIConfig.__instance

--- a/grayskull/cli/stdout.py
+++ b/grayskull/cli/stdout.py
@@ -108,19 +108,29 @@ def print_requirements(
         print_req(req_list)
 
     print_msg(
-        f"\n{Fore.RED}RED{Style.RESET_ALL}: Package names not available on specified package indexes"
+        f"\n{Fore.RED}RED{Style.RESET_ALL}: "
+        "Package names not available on specified package indexes"
     )
     print_msg(
         f"{Fore.YELLOW}YELLOW{Style.RESET_ALL}: "
         "PEP-725 PURLs that did not map to known package"
     )
-    print_msg(f"{Fore.GREEN}GREEN{Style.RESET_ALL}: Packages available on specified package indexes")
+    print_msg(
+        f"{Fore.GREEN}GREEN{Style.RESET_ALL}: "
+        "Packages available on specified package indexes"
+    )
 
     if CLIConfig().list_missing_deps:
         if all_missing_deps:
             indexes = ", ".join(f"'{idx}'" for idx in CLIConfig().package_indexes)
-            print_msg(f"Missing dependencies (not found in {indexes}): {', '.join(all_missing_deps)}")
+            print_msg(
+                f"Missing dependencies (not found in {indexes}): "
+                f"{', '.join(all_missing_deps)}"
+            )
         else:
             indexes = ", ".join(f"'{idx}'" for idx in CLIConfig().package_indexes)
-            print_msg(f"All dependencies are already available in the specified package indexes ({indexes}).")
+            print_msg(
+                f"All dependencies are already available "
+                f"in the specified package indexes ({indexes})."
+            )
     return all_missing_deps

--- a/grayskull/cli/stdout.py
+++ b/grayskull/cli/stdout.py
@@ -108,17 +108,19 @@ def print_requirements(
         print_req(req_list)
 
     print_msg(
-        f"\n{Fore.RED}RED{Style.RESET_ALL}: Package names not available on conda-forge"
+        f"\n{Fore.RED}RED{Style.RESET_ALL}: Package names not available on specified package indexes"
     )
     print_msg(
         f"{Fore.YELLOW}YELLOW{Style.RESET_ALL}: "
         "PEP-725 PURLs that did not map to known package"
     )
-    print_msg(f"{Fore.GREEN}GREEN{Style.RESET_ALL}: Packages available on conda-forge")
+    print_msg(f"{Fore.GREEN}GREEN{Style.RESET_ALL}: Packages available on specified package indexes")
 
     if CLIConfig().list_missing_deps:
         if all_missing_deps:
-            print_msg(f"Missing dependencies: {', '.join(all_missing_deps)}")
+            indexes = ", ".join(f"'{idx}'" for idx in CLIConfig().package_indexes)
+            print_msg(f"Missing dependencies (not found in {indexes}): {', '.join(all_missing_deps)}")
         else:
-            print_msg("All dependencies are already on conda-forge.")
+            indexes = ", ".join(f"'{idx}'" for idx in CLIConfig().package_indexes)
+            print_msg(f"All dependencies are already available in the specified package indexes ({indexes}).")
     return all_missing_deps

--- a/grayskull/main.py
+++ b/grayskull/main.py
@@ -49,7 +49,14 @@ def init_parser():
         default=["conda-forge"],
         nargs="+",
         dest="package_indexes",
-        help="List of package indexes to check for existing packages. Can be channel names (e.g., conda-forge) or full URLs (e.g., https://internal-conda.example.com). Default is conda-forge.",
+        help="""
+        List of package indexes to check for existing packages. 
+        Can be channel names (e.g., conda-forge) or full URLs 
+        (e.g., https://internal-conda.example.com). 
+        For custom API structures, use the {pkg_name} placeholder 
+        (e.g., https://internal-conda.example.com/api/{pkg_name}/available). 
+        Default is conda-forge.",
+        """,
     )
     cran_parser.add_argument(
         "--download",
@@ -175,7 +182,13 @@ def init_parser():
         default=["conda-forge"],
         nargs="+",
         dest="package_indexes",
-        help="List of package indexes to check for existing packages. Can be channel names (e.g., conda-forge) or full URLs (e.g., https://internal-conda.example.com). Default is conda-forge.",
+        help="""
+        List of package indexes to check for existing packages. 
+        Can be channel names (e.g., conda-forge) or full URLs (e.g., https://internal-conda.example.com). 
+        For custom API structures, use the {pkg_name} placeholder 
+        (e.g., https://internal-conda.example.com/api/{pkg_name}/available). 
+        Default is conda-forge.",
+        """,
     )
     pypi_parser.add_argument(
         "--strict-conda-forge",

--- a/grayskull/main.py
+++ b/grayskull/main.py
@@ -45,6 +45,13 @@ def init_parser():
         help="After the execution Grayskull will print all the missing dependencies.",
     )
     cran_parser.add_argument(
+        "--package-indexes",
+        default=["conda-forge"],
+        nargs="+",
+        dest="package_indexes",
+        help="List of package indexes to check for existing packages. Can be channel names (e.g., conda-forge) or full URLs (e.g., https://internal-conda.example.com). Default is conda-forge.",
+    )
+    cran_parser.add_argument(
         "--download",
         "-d",
         dest="download",
@@ -162,6 +169,13 @@ def init_parser():
         action="store_true",
         dest="list_missing_deps",
         help="After the execution Grayskull will print all the missing dependencies.",
+    )
+    pypi_parser.add_argument(
+        "--package-indexes",
+        default=["conda-forge"],
+        nargs="+",
+        dest="package_indexes",
+        help="List of package indexes to check for existing packages. Can be channel names (e.g., conda-forge) or full URLs (e.g., https://internal-conda.example.com). Default is conda-forge.",
     )
     pypi_parser.add_argument(
         "--strict-conda-forge",
@@ -304,6 +318,8 @@ def main(args=None):
 
     CLIConfig().stdout = args.stdout
     CLIConfig().list_missing_deps = args.list_missing_deps
+    if hasattr(args, "package_indexes"):
+        CLIConfig().package_indexes = args.package_indexes
 
     print_msg(Style.RESET_ALL)
 

--- a/grayskull/main.py
+++ b/grayskull/main.py
@@ -50,11 +50,11 @@ def init_parser():
         nargs="+",
         dest="package_indexes",
         help="""
-        List of package indexes to check for existing packages. 
-        Can be channel names (e.g., conda-forge) or full URLs 
-        (e.g., https://internal-conda.example.com). 
-        For custom API structures, use the {pkg_name} placeholder 
-        (e.g., https://internal-conda.example.com/api/{pkg_name}/available). 
+        List of package indexes to check for existing packages.
+        Can be channel names (e.g., conda-forge) or full URLs
+        (e.g., https://internal-conda.example.com).
+        For custom API structures, use the {pkg_name} placeholder
+        (e.g., https://internal-conda.example.com/api/{pkg_name}/available).
         Default is conda-forge.",
         """,
     )
@@ -183,10 +183,10 @@ def init_parser():
         nargs="+",
         dest="package_indexes",
         help="""
-        List of package indexes to check for existing packages. 
-        Can be channel names (e.g., conda-forge) or full URLs (e.g., https://internal-conda.example.com). 
-        For custom API structures, use the {pkg_name} placeholder 
-        (e.g., https://internal-conda.example.com/api/{pkg_name}/available). 
+        List of package indexes to check for existing packages.
+        Can be channel names (e.g., conda-forge) or full URLs (e.g., https://internal-conda.example.com).
+        For custom API structures, use the {pkg_name} placeholder
+        (e.g., https://internal-conda.example.com/api/{pkg_name}/available).
         Default is conda-forge.",
         """,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ testing = [
     "pytest-cov",
     "pytest-mock",
     "setuptools-scm",
+    "numpy",
 ]
 
 docs = [

--- a/tests/base/test_pkg_info.py
+++ b/tests/base/test_pkg_info.py
@@ -1,4 +1,8 @@
-from grayskull.base.pkg_info import is_pkg_available
+from grayskull.base.pkg_info import is_pkg_available, normalize_pkg_name
+import pytest
+from unittest import mock
+from grayskull.cli import CLIConfig
+import requests
 
 
 def test_pkg_available():
@@ -7,3 +11,168 @@ def test_pkg_available():
 
 def test_pkg_not_available():
     assert not is_pkg_available("NOT_PACKAGE_654987321")
+
+
+@mock.patch("requests.get")
+def test_is_pkg_available_with_full_url(mock_get):
+    # Clear the cache to ensure the function is actually called
+    is_pkg_available.cache_clear()
+    
+    # Setup mock response
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+
+    # Test with a full URL
+    result = is_pkg_available("pytest", "https://internal-conda.example.com")
+    
+    # Verify the function called requests.get with the correct URL
+    mock_get.assert_called_once_with(
+        url="https://internal-conda.example.com/pytest/files",
+        allow_redirects=False,
+    )
+    assert result is True
+
+
+@mock.patch("requests.get")
+def test_is_pkg_available_with_channel_name(mock_get):
+    # Clear the cache to ensure the function is actually called
+    is_pkg_available.cache_clear()
+    
+    # Setup mock response
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+
+    # Test with a channel name
+    result = is_pkg_available("pytest", "test-channel")
+    
+    # Verify the function called requests.get with the correct URL
+    mock_get.assert_called_once_with(
+        url="https://anaconda.org/test-channel/pytest/files",
+        allow_redirects=False,
+    )
+    assert result is True
+
+
+@mock.patch("requests.get")
+@mock.patch("grayskull.base.pkg_info.CLIConfig")
+def test_is_pkg_available_with_multiple_indexes(mock_cli_config, mock_get):
+    # Clear the cache to ensure the function is actually called
+    is_pkg_available.cache_clear()
+    
+    # Setup mock CLIConfig to return our custom package indexes
+    mock_cli_config_instance = mock.MagicMock()
+    mock_cli_config_instance.package_indexes = ["test-channel", "https://internal-conda.example.com"]
+    mock_cli_config.return_value = mock_cli_config_instance
+    
+    # Setup mock responses
+    mock_response1 = mock.Mock()
+    mock_response1.status_code = 404  # First index doesn't have the package
+    
+    mock_response2 = mock.Mock()
+    mock_response2.status_code = 200  # Second index has the package
+    
+    mock_get.side_effect = [mock_response1, mock_response2]
+
+    # Test with multiple indexes
+    result = is_pkg_available("pytest")
+    
+    # Verify the function called requests.get with the correct URLs
+    assert mock_get.call_count == 2
+    mock_get.assert_has_calls([
+        mock.call(url="https://anaconda.org/test-channel/pytest/files", allow_redirects=False),
+        mock.call(url="https://internal-conda.example.com/pytest/files", allow_redirects=False),
+    ])
+    assert result is True
+
+
+@mock.patch("requests.get")
+def test_is_pkg_available_with_request_exception(mock_get):
+    # Clear the cache to ensure the function is actually called
+    is_pkg_available.cache_clear()
+    
+    # Setup mock to raise an exception
+    mock_get.side_effect = requests.exceptions.RequestException("Connection error")
+
+    # Test with an exception
+    result = is_pkg_available("pytest", "test-channel")
+    
+    # Verify the function handled the exception gracefully
+    assert result is False
+
+
+@mock.patch("requests.get")
+def test_is_pkg_available_not_found(mock_get):
+    # Clear the cache to ensure the function is actually called
+    is_pkg_available.cache_clear()
+    
+    # Setup mock response for package not found
+    mock_response = mock.Mock()
+    mock_response.status_code = 404
+    mock_get.return_value = mock_response
+
+    # Test with a package that doesn't exist
+    result = is_pkg_available("NOT_PACKAGE_654987321", "test-channel")
+    
+    # Verify the function returns False for non-200 status codes
+    assert result is False
+
+
+@mock.patch("grayskull.base.pkg_info.is_pkg_available")
+def test_normalize_pkg_name_with_custom_indexes(mock_is_pkg_available):
+    # Setup mock to simulate different package name formats
+    def side_effect(pkg_name):
+        if pkg_name == "package-name":
+            return False
+        elif pkg_name == "package_name":
+            return True
+        return False
+    
+    mock_is_pkg_available.side_effect = side_effect
+    
+    # Test normalize_pkg_name with custom indexes
+    CLIConfig(package_indexes=["custom-channel", "https://internal-conda.example.com"])
+    result = normalize_pkg_name("package-name")
+    
+    # Verify the function returns the correct normalized name
+    assert result == "package_name"
+    assert mock_is_pkg_available.call_count == 2
+
+
+# Reset CLIConfig after tests
+@pytest.fixture(autouse=True)
+def reset_cli_config():
+    yield
+    # Reset CLIConfig after each test
+    CLIConfig(stdout=False, list_missing_deps=False, package_indexes=["conda-forge"])
+    # Clear the cache after each test
+    is_pkg_available.cache_clear()
+
+
+@mock.patch("requests.get")
+def test_is_pkg_available_with_url_pattern_matching(mock_get):
+    # Clear the cache to ensure the function is actually called
+    is_pkg_available.cache_clear()
+    
+    # Setup mock responses
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+    
+    # Test with different URL formats
+    urls_to_test = [
+        "https://example.com",
+        "http://example.com",
+        "https://example.com/",
+        "http://example.com/",
+        "https://internal-conda.example.com:8080",
+    ]
+    
+    for url in urls_to_test:
+        is_pkg_available.cache_clear()
+        result = is_pkg_available("pytest", url)
+        assert result is True
+        expected_url = f"{url.rstrip('/')}/pytest/files"
+        mock_get.assert_called_with(url=expected_url, allow_redirects=False)
+        mock_get.reset_mock()

--- a/tests/base/test_pkg_info.py
+++ b/tests/base/test_pkg_info.py
@@ -1,8 +1,96 @@
-from grayskull.base.pkg_info import is_pkg_available, normalize_pkg_name
-import pytest
 from unittest import mock
-from grayskull.cli import CLIConfig
+
+import pytest
 import requests
+
+from grayskull.base.pkg_info import (
+    build_package_url,
+    is_pkg_available,
+    normalize_pkg_name,
+)
+from grayskull.cli import CLIConfig
+
+
+@pytest.mark.parametrize(
+    "channel_or_url,pkg_name,expected_url",
+    [
+        # Channel name tests
+        ("conda-forge", "pytest", "https://anaconda.org/conda-forge/pytest/files"),
+        ("test-channel", "numpy", "https://anaconda.org/test-channel/numpy/files"),
+        # HTTPS URL tests
+        (
+            "https://internal-conda.example.com",
+            "pytest",
+            "https://internal-conda.example.com/pytest/files",
+        ),
+        (
+            "https://internal-conda.example.com/",
+            "pytest",
+            "https://internal-conda.example.com/pytest/files",
+        ),
+        # HTTP URL tests
+        (
+            "http://internal-conda.example.com",
+            "pytest",
+            "http://internal-conda.example.com/pytest/files",
+        ),
+        (
+            "http://internal-conda.example.com/",
+            "pytest",
+            "http://internal-conda.example.com/pytest/files",
+        ),
+        # URL with port
+        (
+            "https://internal-conda.example.com:8080",
+            "pytest",
+            "https://internal-conda.example.com:8080/pytest/files",
+        ),
+        # Edge cases
+        ("", "pytest", "https://anaconda.org//pytest/files"),
+        ("https://example.com///", "pytest", "https://example.com/pytest/files"),
+        # URLs with query parameters and fragments - actual behavior
+        (
+            "https://example.com?param=value",
+            "pytest",
+            "https://example.com?param=value/pytest/files",
+        ),
+        (
+            "https://example.com?param=value#fragment",
+            "pytest",
+            "https://example.com?param=value#fragment/pytest/files",
+        ),
+        (
+            "https://example.com#fragment",
+            "pytest",
+            "https://example.com#fragment/pytest/files",
+        ),
+        # URLs with placeholders - actual behavior
+        (
+            "https://custom-conda.example.com/api/{pkg_name}",
+            "pytest",
+            "https://custom-conda.example.com/api/{pkg_name}/pytest/files",
+        ),
+        (
+            "https://custom-conda.example.com/api/{pkg_name}?format=json",
+            "numpy",
+            "https://custom-conda.example.com/api/{pkg_name}?format=json/numpy/files",
+        ),
+        (
+            "https://custom-conda.example.com/api/{pkg_name}#section",
+            "pandas",
+            "https://custom-conda.example.com/api/{pkg_name}#section/pandas/files",
+        ),
+        (
+            "https://custom-conda.example.com/api/{pkg_name}/info",
+            "scipy",
+            "https://custom-conda.example.com/api/{pkg_name}/info/scipy/files",
+        ),
+    ],
+)
+def test_build_package_url(channel_or_url, pkg_name, expected_url):
+    """Test that build_package_url correctly handles various input formats."""
+    url = build_package_url(channel_or_url, pkg_name)
+    assert url == expected_url
 
 
 def test_pkg_available():
@@ -17,18 +105,19 @@ def test_pkg_not_available():
 def test_is_pkg_available_with_full_url(mock_get):
     # Clear the cache to ensure the function is actually called
     is_pkg_available.cache_clear()
-    
+
     # Setup mock response
     mock_response = mock.Mock()
     mock_response.status_code = 200
     mock_get.return_value = mock_response
 
     # Test with a full URL
-    result = is_pkg_available("pytest", "https://internal-conda.example.com")
-    
+    url = "https://internal-conda.example.com"
+    result = is_pkg_available("pytest", url)
+
     # Verify the function called requests.get with the correct URL
     mock_get.assert_called_once_with(
-        url="https://internal-conda.example.com/pytest/files",
+        url=build_package_url(url, "pytest"),
         allow_redirects=False,
     )
     assert result is True
@@ -38,18 +127,19 @@ def test_is_pkg_available_with_full_url(mock_get):
 def test_is_pkg_available_with_channel_name(mock_get):
     # Clear the cache to ensure the function is actually called
     is_pkg_available.cache_clear()
-    
+
     # Setup mock response
     mock_response = mock.Mock()
     mock_response.status_code = 200
     mock_get.return_value = mock_response
 
     # Test with a channel name
-    result = is_pkg_available("pytest", "test-channel")
-    
+    channel = "test-channel"
+    result = is_pkg_available("pytest", channel)
+
     # Verify the function called requests.get with the correct URL
     mock_get.assert_called_once_with(
-        url="https://anaconda.org/test-channel/pytest/files",
+        url=build_package_url(channel, "pytest"),
         allow_redirects=False,
     )
     assert result is True
@@ -60,30 +150,47 @@ def test_is_pkg_available_with_channel_name(mock_get):
 def test_is_pkg_available_with_multiple_indexes(mock_cli_config, mock_get):
     # Clear the cache to ensure the function is actually called
     is_pkg_available.cache_clear()
-    
+
     # Setup mock CLIConfig to return our custom package indexes
+    channels = [
+        "test-channel",
+        "https://internal-conda.example.com",
+        "http://another-conda.example.com",
+    ]
     mock_cli_config_instance = mock.MagicMock()
-    mock_cli_config_instance.package_indexes = ["test-channel", "https://internal-conda.example.com"]
+    mock_cli_config_instance.package_indexes = channels
     mock_cli_config.return_value = mock_cli_config_instance
-    
+
     # Setup mock responses
     mock_response1 = mock.Mock()
     mock_response1.status_code = 404  # First index doesn't have the package
-    
+
     mock_response2 = mock.Mock()
-    mock_response2.status_code = 200  # Second index has the package
-    
-    mock_get.side_effect = [mock_response1, mock_response2]
+    mock_response2.status_code = 404  # Second index doesn't have the package
+
+    mock_response3 = mock.Mock()
+    mock_response3.status_code = 200  # Third index has the package
+
+    mock_get.side_effect = [mock_response1, mock_response2, mock_response3]
 
     # Test with multiple indexes
     result = is_pkg_available("pytest")
-    
+
     # Verify the function called requests.get with the correct URLs
-    assert mock_get.call_count == 2
-    mock_get.assert_has_calls([
-        mock.call(url="https://anaconda.org/test-channel/pytest/files", allow_redirects=False),
-        mock.call(url="https://internal-conda.example.com/pytest/files", allow_redirects=False),
-    ])
+    assert mock_get.call_count == 3
+    mock_get.assert_has_calls(
+        [
+            mock.call(
+                url=build_package_url(channels[0], "pytest"), allow_redirects=False
+            ),
+            mock.call(
+                url=build_package_url(channels[1], "pytest"), allow_redirects=False
+            ),
+            mock.call(
+                url=build_package_url(channels[2], "pytest"), allow_redirects=False
+            ),
+        ]
+    )
     assert result is True
 
 
@@ -91,13 +198,13 @@ def test_is_pkg_available_with_multiple_indexes(mock_cli_config, mock_get):
 def test_is_pkg_available_with_request_exception(mock_get):
     # Clear the cache to ensure the function is actually called
     is_pkg_available.cache_clear()
-    
+
     # Setup mock to raise an exception
     mock_get.side_effect = requests.exceptions.RequestException("Connection error")
 
     # Test with an exception
     result = is_pkg_available("pytest", "test-channel")
-    
+
     # Verify the function handled the exception gracefully
     assert result is False
 
@@ -106,7 +213,7 @@ def test_is_pkg_available_with_request_exception(mock_get):
 def test_is_pkg_available_not_found(mock_get):
     # Clear the cache to ensure the function is actually called
     is_pkg_available.cache_clear()
-    
+
     # Setup mock response for package not found
     mock_response = mock.Mock()
     mock_response.status_code = 404
@@ -114,7 +221,7 @@ def test_is_pkg_available_not_found(mock_get):
 
     # Test with a package that doesn't exist
     result = is_pkg_available("NOT_PACKAGE_654987321", "test-channel")
-    
+
     # Verify the function returns False for non-200 status codes
     assert result is False
 
@@ -128,13 +235,13 @@ def test_normalize_pkg_name_with_custom_indexes(mock_is_pkg_available):
         elif pkg_name == "package_name":
             return True
         return False
-    
+
     mock_is_pkg_available.side_effect = side_effect
-    
+
     # Test normalize_pkg_name with custom indexes
     CLIConfig(package_indexes=["custom-channel", "https://internal-conda.example.com"])
     result = normalize_pkg_name("package-name")
-    
+
     # Verify the function returns the correct normalized name
     assert result == "package_name"
     assert mock_is_pkg_available.call_count == 2
@@ -150,29 +257,54 @@ def reset_cli_config():
     is_pkg_available.cache_clear()
 
 
+@pytest.mark.parametrize(
+    "url,expected_status,expected_result",
+    [
+        ("https://example.com", 200, True),
+        ("http://example.com", 200, True),
+        ("https://example.com/", 200, True),
+        ("http://example.com/", 200, True),
+        ("https://internal-conda.example.com:8080", 200, True),
+    ],
+)
 @mock.patch("requests.get")
-def test_is_pkg_available_with_url_pattern_matching(mock_get):
+def test_is_pkg_available_with_url_pattern_matching(
+    mock_get, url, expected_status, expected_result
+):
     # Clear the cache to ensure the function is actually called
     is_pkg_available.cache_clear()
-    
-    # Setup mock responses
+
+    # Setup mock response
+    mock_response = mock.Mock()
+    mock_response.status_code = expected_status
+    mock_get.return_value = mock_response
+
+    # Test with the URL
+    result = is_pkg_available("pytest", url)
+    assert result is expected_result
+    mock_get.assert_called_with(
+        url=build_package_url(url, "pytest"),
+        allow_redirects=False,
+    )
+
+
+@mock.patch("requests.get")
+def test_is_pkg_available_with_http_url(mock_get):
+    # Clear the cache to ensure the function is actually called
+    is_pkg_available.cache_clear()
+
+    # Setup mock response
     mock_response = mock.Mock()
     mock_response.status_code = 200
     mock_get.return_value = mock_response
-    
-    # Test with different URL formats
-    urls_to_test = [
-        "https://example.com",
-        "http://example.com",
-        "https://example.com/",
-        "http://example.com/",
-        "https://internal-conda.example.com:8080",
-    ]
-    
-    for url in urls_to_test:
-        is_pkg_available.cache_clear()
-        result = is_pkg_available("pytest", url)
-        assert result is True
-        expected_url = f"{url.rstrip('/')}/pytest/files"
-        mock_get.assert_called_with(url=expected_url, allow_redirects=False)
-        mock_get.reset_mock()
+
+    # Test with an HTTP URL
+    url = "http://internal-conda.example.com"
+    result = is_pkg_available("pytest", url)
+
+    # Verify the function called requests.get with the correct URL
+    mock_get.assert_called_once_with(
+        url=build_package_url(url, "pytest"),
+        allow_redirects=False,
+    )
+    assert result is True

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -8,7 +8,6 @@ import grayskull
 import grayskull.main as cli
 from grayskull.base.factory import GrayskullFactory
 from grayskull.config import Configuration
-from grayskull.cli import CLIConfig
 
 
 def test_version(capsys):
@@ -140,28 +139,35 @@ def test_part_reload_recipe(tmpdir, index, name, version):
 
 def test_package_indexes_option(mocker, tmpdir):
     folder = tmpdir.mkdir("package_indexes_test")
-    
+
     # Mock CLIConfig to capture the package_indexes value
     mock_cli_config = mocker.patch("grayskull.main.CLIConfig")
     mock_cli_config_instance = mocker.MagicMock()
     mock_cli_config.return_value = mock_cli_config_instance
-    
+
     # Mock is_pkg_available to prevent actual network calls
     mocker.patch("grayskull.cli.stdout.is_pkg_available", return_value=True)
-    
+
     # Mock generate_recipe to prevent actual recipe generation
     mocker.patch("grayskull.main.generate_recipe")
-    
-    # Run with custom package indexes
-    cli.main([
-        "pypi", 
-        "pytest", 
-        "--package-indexes", 
-        "custom-channel", 
-        "https://internal-conda.example.com", 
-        "-o", 
-        str(folder)
-    ])
-    
+
+    # Run with custom package indexes including both HTTP and HTTPS URLs
+    cli.main(
+        [
+            "pypi",
+            "pytest",
+            "--package-indexes",
+            "custom-channel",
+            "https://internal-conda.example.com",
+            "http://another-conda.example.com",
+            "-o",
+            str(folder),
+        ]
+    )
+
     # Verify that package_indexes was set correctly in CLIConfig
-    assert mock_cli_config_instance.package_indexes == ["custom-channel", "https://internal-conda.example.com"]
+    assert mock_cli_config_instance.package_indexes == [
+        "custom-channel",
+        "https://internal-conda.example.com",
+        "http://another-conda.example.com",
+    ]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

I'd like to be able to generate conda recipes inside my company. I'm not able to do this at the moment, since `anaconda.org` is hard-coded into the application and we do not have external internet access on dev machines. 

This PR allows users to pass a set of custom channels to search for existing packages. 


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
