### PR TITLE
properly include pep725 optional dependencies

### DIFF
--- a/grayskull/strategy/py_toml.py
+++ b/grayskull/strategy/py_toml.py
@@ -217,6 +217,27 @@ def get_pep725_mapping(purl: str):
         "pkg:generic/singular": "singular",
         "pkg:generic/symmetrica": "symmetrica",
         "pkg:generic/sympow": "sympow",
+        "pkg:generic/lrslib": "lrslib",
+        "pkg:generic/bliss": "bliss",
+        "pkg:generic/coxeter3": "# coxeter3 # Not available on conda-forge",
+        "pkg:generic/mcqd": "# mcqd # Not available on conda-forge",
+        "pkg:generic/meataxe": "# meataxe # Not available on conda-forge",
+        "pkg:generic/sirocco": "sirocco",
+        "pkg:generic/tdlib": "# tdlib # Not available on conda-forge",
+        "pkg:generic/4ti2": "4ti2",
+        "pkg:generic/benzene": "# benzene # Not available on conda-forge",
+        "pkg:generic/buckygen": "# buckygen # Not available on conda-forge",
+        "pkg:generic/csdp": "# csdp # Not available on conda-forge",
+        "pkg:generic/frobby": "# frobby # Not available on conda-forge",
+        "pkg:generic/kenzo": "# kenzo # Not available on conda-forge",
+        "pkg:generic/latte-integrale": "latte-integrale",
+        "pkg:generic/plantri": "# plantri # Not available on conda-forge",
+        "pkg:generic/qepcad": "# qepcad # Not available on conda-forge",
+        "pkg:generic/tides": "# tides # Not available on conda-forge",
+        "pkg:generic/tachyon": "tachyon",
+        "pkg:generic/sagemath-elliptic-curves": "sagemath-db-elliptic-curves",
+        "pkg:generic/sagemath-polytopes-db": "sagemath-db-polytopes",
+        "pkg:generic/sagemath-graphs": "sagemath-db-graphs",
     }
     return package_mapping.get(purl, purl)
 
@@ -239,13 +260,14 @@ def add_pep725_metadata(metadata: dict, toml_metadata: dict):
         requirements[conda_section].extend(
             [get_pep725_mapping(purl) for purl in externals.get(pep725_section, [])]
         )
-        # TODO: handle optional dependencies properly
-        optional_features = toml_metadata.get(f"optional-{pep725_section}", {})
+        optional_features = externals.get(f"optional-{pep725_section}", {})
         for feature_name, feature_deps in optional_features.items():
             requirements[conda_section].append(
                 f'# OPTIONAL dependencies from feature "{feature_name}"'
             )
-            requirements[conda_section].extend(feature_deps)
+            requirements[conda_section].extend(
+                [get_pep725_mapping(purl) for purl in feature_deps]
+            )
         if not requirements[conda_section]:
             del requirements[conda_section]
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Currently, the code looked for the `optional-dependencies` group in the root of `pyproject.toml`. This is fixed to correctly use the `externals` section. Moreover, the optional deps purls are correctly mapped to the conda package.

Finally, the purl - conda package map is slightly expanded.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
