### PR TITLE
Remove pyct from config.yaml

### DIFF
--- a/grayskull/strategy/config.yaml
+++ b/grayskull/strategy/config.yaml
@@ -387,10 +387,6 @@ pvlib:
   conda_forge: pvlib-python
   import_name: pvlib
 
-pyct:
-  conda_forge: pyct-core
-  import_name: pyct
-
 pyqt4:
   import_name: pyqt4
   conda_forge: pyqt


### PR DESCRIPTION
Since pyct-core has been archived (see https://github.com/conda-forge/pyct-core-feedstock/issues/5), there's no longer need to map from `pyct` to `pyct-core`.