### PR TITLE
Fix sdist package name

### DIFF
--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -588,16 +588,11 @@ def update_recipe(recipe: Recipe, config: Configuration, all_sections: Iterable[
         if metadata.get(section):
             if section == "package":
                 package_metadata = dict(metadata[section])
-                if package_metadata["name"].lower() == config.name.lower():
-                    # In case of from_local_sdist, the initial name set in the recipe
-                    # came from the sdist filename and shall be updated.
-                    # No need otherwise.
-                    if not config.from_local_sdist:
-                        package_metadata.pop("name")
-                else:
-                    package_metadata["name"] = package_metadata["name"].replace(
-                        config.name, "<{ name|lower }}"
-                    )
+                # In case of from_local_sdist, the initial name set in the recipe
+                # came from the sdist filename and shall be updated.
+                # No need otherwise.
+                if not config.from_local_sdist:
+                    package_metadata.pop("name")
 
                 set_global_jinja_var(recipe, "version", package_metadata["version"])
                 config.version = package_metadata["version"]

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -587,13 +587,10 @@ def update_recipe(recipe: Recipe, config: Configuration, all_sections: Iterable[
         metadata[section] = remove_all_inner_nones(metadata.get(section, {}))
         if metadata.get(section):
             if section == "package":
+                # Update both name and version keys in that section
+                # name is usually correct in the initial recipe but
+                # might not in some cases (local sdist)
                 package_metadata = dict(metadata[section])
-                # In case of from_local_sdist, the initial name set in the recipe
-                # came from the sdist filename and shall be updated.
-                # No need otherwise.
-                if not config.from_local_sdist:
-                    package_metadata.pop("name")
-
                 set_global_jinja_var(recipe, "version", package_metadata["version"])
                 config.version = package_metadata["version"]
                 package_metadata["version"] = "<{ version }}"

--- a/grayskull/strategy/pypi.py
+++ b/grayskull/strategy/pypi.py
@@ -589,10 +589,11 @@ def update_recipe(recipe: Recipe, config: Configuration, all_sections: Iterable[
             if section == "package":
                 package_metadata = dict(metadata[section])
                 if package_metadata["name"].lower() == config.name.lower():
-                    if config.from_local_sdist:
-                        # Initial name set in the recipe came from the sdist filename
-                        set_global_jinja_var(recipe, "name", package_metadata["name"])
-                    package_metadata.pop("name")
+                    # In case of from_local_sdist, the initial name set in the recipe
+                    # came from the sdist filename and shall be updated.
+                    # No need otherwise.
+                    if not config.from_local_sdist:
+                        package_metadata.pop("name")
                 else:
                     package_metadata["name"] = package_metadata["name"].replace(
                         config.name, "<{ name|lower }}"

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -1631,7 +1631,13 @@ def test_create_recipe_from_local_sdist(pkg_pytest):
     assert recipe["about"]["summary"] == "pytest: simple powerful testing with Python"
     assert recipe["about"]["license"] == "MIT"
     assert recipe["about"]["license_file"] == "LICENSE"
-    assert get_global_jinja_var(recipe, "name") == "pytest"
+    assert recipe["package"]["name"] == "pytest"
+    # No name variable defined
+    with pytest.raises(
+        ValueError, match=r"It was not possible to find the requested jinja variable"
+    ):
+        get_global_jinja_var(recipe, "name")
+    assert recipe["package"]["version"] == "<{ version }}"
     assert get_global_jinja_var(recipe, "version") == "5.3.5"
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

In https://github.com/marcelotrevisani/souschef/pull/64, the `name` variable was removed from the generated recipe.
This broke recipe generation from local sdist when the package name and sdist filename didn't match.

`grayskull` was still inserting the correct name as variable but it wasn't used anymore:

```
{% set version = "1.9.1.dev1+gfbc6c9ac2" %}
{% set name = "sardana-flexpes" %}

package:
  name: sardana_flexpes
  version: {{ version }}
```

Instead of using `set_global_jinja_var(recipe, "name",...)`, we now update directly the `name` key in the `package` section.

While fixing this bug, I saw another issue:

```
 package_metadata["name"] = package_metadata["name"].replace(
     config.name, "<{ name|lower }}"
 )
```

This would use  the `name` variable, which isn't defined anymore, leading to a broken recipe.
I couldn't reproduce the initial issue https://github.com/conda/grayskull/issues/383. I assume that the `package_metadata["name"]` is already what we want and we don't need to update anything?

@woutdenolf do you have any input on this?