### PR TITLE
Improve license metadata for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >=61", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools >=77", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,7 +10,7 @@ authors = [
 description = "Project to generate recipes for conda packages"
 readme = "README.md"
 keywords = ["conda"]
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
This improves the license metadata to use [PEP 639](https://peps.python.org/pep-0639/) which requires setuptools 77 or later. It resolves a build message:
```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2027-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```