### PR TITLE
Fix MANIFEST.in for setuptools

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,14 @@
 include LICENSE
-include README.rst
-include licence/licence_cache.json
-recursive-include license/data * *.*
+include README.md
+graft grayskull/license
 
-exclude .github
-exclude azure-pipelines.yml
+prune .github
+exclude .gitattributes
 exclude .gitignore
 exclude .pre-commit-config.yaml
 exclude .coveragerc
+exclude *.lock
+exclude *.y[a]ml
 prune tests/
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
This resolves a few warnings from building this package, e.g. with `uv build --sdist`:
```
warning: no files found matching 'README.rst'
warning: no files found matching 'licence/licence_cache.json'
warning: no files found matching '*' under directory 'license/data'
warning: no files found matching '*.*' under directory 'license/data'
warning: no previously-included files found matching '.github'
warning: no previously-included files matching '__pycache__' found under directory '*'
warning: no previously-included files matching '*.py[co]' found under directory '*'
```
It also excludes environment.yaml, .gitattributes, pixi.lock, uv.lock and everything under .github/ in the resulting source distribution file.