### PR TITLE
Switch PyPI sources to use `files.pythonhosted.org`

### DIFF
--- a/grayskull/config.py
+++ b/grayskull/config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from grayskull.cli.parser import parse_pkg_name_version
 from grayskull.utils import PyVer
 
-DEFAULT_PYPI_URL = "https://pypi.org"
+DEFAULT_PYPI_URL = "https://files.pythonhosted.org"
 DEFAULT_PYPI_META_URL = "https://pypi.org/pypi"
 
 

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -76,7 +76,7 @@ def test_change_pypi_url(mocker):
         "pytest=5.3.2",
         is_strict_cf=False,
         download=False,
-        url_pypi="https://pypi.org",
+        url_pypi="https://files.pythonhosted.org",
         url_pypi_metadata="http://url_pypi.com/abc",
         sections_populate=None,
         from_local_sdist=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,8 @@ def pkg_pytest(tmpdir_factory) -> str:
     # Correct info should be extracted from the metadata and not filename
     dest_pkg = str(folder / "PYTEST-PKG-1.0.0.tar.gz")
     download_sdist_pkg(
-        "https://pypi.org/packages/source/p/pytest/pytest-5.3.5.tar.gz", dest_pkg
+        "https://files.pythonhosted.org/packages/source/p/pytest/pytest-5.3.5.tar.gz",
+        dest_pkg,
     )
     shutil.unpack_archive(dest_pkg, str(folder))
     return dest_pkg

--- a/tests/data/poetry/langchain-expected.yaml
+++ b/tests/data/poetry/langchain-expected.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/l/langchain/langchain-{{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/source/l/langchain/langchain-{{ version }}.tar.gz
   sha256: 95a93c966b1a2ff056c43870747aba1c39924c145179f0b8ffa27fef6a525610
 
 build:

--- a/tests/test_py_base.py
+++ b/tests/test_py_base.py
@@ -129,7 +129,7 @@ def test_get_sdist_metadata_packages_top_level():
     name_nor = name.replace("-", "_")
     pkg_ver = "0.11.1"
     sdist_metadata = get_sdist_metadata(
-        f"https://pypi.org/packages/source/t/{name}/{name_nor}-{pkg_ver}.tar.gz",
+        f"https://files.pythonhosted.org/packages/source/t/{name}/{name_nor}-{pkg_ver}.tar.gz",
         Configuration(name=name, version=pkg_ver),
     )
     assert sdist_metadata["name"] == name
@@ -144,7 +144,7 @@ def test_get_sdist_metadata_no_top_level():
     name_nor = name.replace("-", "_")
     pkg_ver = "0.7.2"
     sdist_metadata = get_sdist_metadata(
-        f"https://pypi.org/packages/source/g/{name}/{name_nor}-{pkg_ver}.tar.gz",
+        f"https://files.pythonhosted.org/packages/source/g/{name}/{name_nor}-{pkg_ver}.tar.gz",
         Configuration(name=name, version=pkg_ver),
     )
     assert sdist_metadata["name"] == name

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -186,7 +186,7 @@ def test_get_extra_from_requires_dist():
 def dask_sdist_metadata_setup():
     config = Configuration(name="dask")
     return get_sdist_metadata(
-        "https://pypi.org/packages/source/d/dask/dask-2022.6.1.tar.gz",
+        "https://files.pythonhosted.org/packages/source/d/dask/dask-2022.6.1.tar.gz",
         config,
     )
 
@@ -311,7 +311,7 @@ def test_compose_test_section_with_requirements_setup(dask_sdist_metadata_setup)
 def dask_sdist_metadata_pyproject():
     config = Configuration(name="dask")
     return get_sdist_metadata(
-        "https://pypi.org/packages/source/d/dask/dask-2025.3.0.tar.gz",
+        "https://files.pythonhosted.org/packages/source/d/dask/dask-2025.3.0.tar.gz",
         config,
     )
 
@@ -457,7 +457,8 @@ def test_compose_test_section_with_console_scripts():
     config = Configuration(name="pytest", version="7.1.2")
     metadata1 = get_pypi_metadata(config)
     metadata2 = get_sdist_metadata(
-        "https://pypi.org/packages/source/p/pytest/pytest-7.1.2.tar.gz", config
+        "https://files.pythonhosted.org/packages/source/p/pytest/pytest-7.1.2.tar.gz",
+        config,
     )
     metadata = merge_pypi_sdist_metadata(metadata1, metadata2, config)
     test_requirements = []
@@ -791,7 +792,7 @@ def test_get_sha256_from_pypi_metadata():
 def test_injection_distutils(name):
     config = Configuration(name="hypothesis")
     data = get_sdist_metadata(
-        "https://pypi.org/packages/source/h/hypothesis/hypothesis-5.5.1.tar.gz",
+        "https://files.pythonhosted.org/packages/source/h/hypothesis/hypothesis-5.5.1.tar.gz",
         config,
     )
     assert sorted(data["install_requires"]) == sorted(
@@ -808,7 +809,8 @@ def test_injection_distutils(name):
 def test_injection_distutils_pytest():
     config = Configuration(name="pytest", version="5.3.2")
     data = get_sdist_metadata(
-        "https://pypi.org/packages/source/p/pytest/pytest-5.3.2.tar.gz", config
+        "https://files.pythonhosted.org/packages/source/p/pytest/pytest-5.3.2.tar.gz",
+        config,
     )
     assert sorted(data["install_requires"]) == sorted(
         [
@@ -833,7 +835,7 @@ def test_injection_distutils_pytest():
 def test_injection_distutils_compiler_gsw():
     config = Configuration(name="gsw", version="3.6.19")
     data = get_sdist_metadata(
-        "https://pypi.org/packages/source/g/gsw/gsw-3.6.19.tar.gz", config
+        "https://files.pythonhosted.org/packages/source/g/gsw/gsw-3.6.19.tar.gz", config
     )
     assert data.get("compilers") == ["c"]
     assert data["name"] == "gsw"
@@ -843,7 +845,7 @@ def test_injection_distutils_setup_reqs_ensure_list():
     pkg_name, pkg_ver = "pyinstaller-hooks-contrib", "2020.7"
     config = Configuration(name=pkg_name, version=pkg_ver)
     data = get_sdist_metadata(
-        f"https://pypi.org/packages/source/p/{pkg_name}/{pkg_name}-{pkg_ver}.tar.gz",
+        f"https://files.pythonhosted.org/packages/source/p/{pkg_name}/{pkg_name}-{pkg_ver}.tar.gz",
         config,
     )
     assert data.get("setup_requires") == ["setuptools >= 30.3.0"]
@@ -1485,7 +1487,8 @@ def test_recipe_with_just_py_modules():
 def test_recipe_extension():
     recipe = create_python_recipe("azure-identity=1.3.1")[0]
     assert (
-        recipe["source"]["url"] == "https://pypi.org/packages/source/a/azure-identity/"
+        recipe["source"]["url"]
+        == "https://files.pythonhosted.org/packages/source/a/azure-identity/"
         "azure-identity-{{ version }}.zip"
     )
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fetch PyPI sources via `files.pythonhosted.org` directly rather than `pypi.org`.  This is the canonical location per upstream documentation: https://docs.pypi.org/api/#predictable-urls

It saves a single unnecessary redirect and reduces load off `pypi.org`, though it seems that currently both hostnames are served off the same server.  It also follows suit with what other distributions are doing, e.g. Arch Linux and Gentoo:
https://wiki.archlinux.org/title/Python_package_guidelines#Source https://gitweb.gentoo.org/repo/gentoo.git/tree/eclass/pypi.eclass#n173