### PR TITLE
Default to v1 recipe format

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ grayskull pypi pytest
 ```
 
 After that `grayskull` will create a folder with the same name as the package
-and inside this folder the generated recipe will be present (`meta.yaml`).
+and inside this folder the generated recipe will be present (`recipe.yaml`).
+Pass `--no-use-v1-format` to generate a legacy `meta.yaml` recipe instead.
 
 * Example with `pytest` (`grayskull pypi pytest`):
 

--- a/grayskull/main.py
+++ b/grayskull/main.py
@@ -110,11 +110,10 @@ def init_parser():
     cran_parser.add_argument(
         "--use-v1-format",
         "-u",
-        default=False,
-        action="store_true",
+        default=True,
+        action=argparse.BooleanOptionalAction,
         dest="use_v1_format",
-        help="Returns a recipe file in the V1 format, used by rattler-build."
-        " NOTE: This is experimental.",
+        help="Return a recipe file in the V1 format (default).",
     )
     # create parser for pypi
     pypi_parser = subparsers.add_parser("pypi", help="Options to generate PyPI recipes")
@@ -300,11 +299,10 @@ def init_parser():
     pypi_parser.add_argument(
         "--use-v1-format",
         "-u",
-        default=False,
-        action="store_true",
+        default=True,
+        action=argparse.BooleanOptionalAction,
         dest="use_v1_format",
-        help="Returns a recipe file in the V1 format, used by rattler-build."
-        " NOTE: This is experimental.",
+        help="Return a recipe file in the V1 format (default).",
     )
 
     return parser

--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -19,7 +19,17 @@ def test_version(capsys):
 def test_pypi_cmd(tmpdir):
     out_folder = tmpdir.mkdir("out")
     cli.main(
-        ["pypi", "pytest=5.3.2", "-o", str(out_folder), "-m", "m1", "m2", "--download"]
+        [
+            "pypi",
+            "pytest=5.3.2",
+            "-o",
+            str(out_folder),
+            "-m",
+            "m1",
+            "m2",
+            "--download",
+            "--no-use-v1-format",
+        ]
     )
     pytest_folder = out_folder / "pytest"
     assert pytest_folder.isdir()
@@ -59,7 +69,9 @@ def test_msg_missing_pkg_pypi(capsys):
 
 def test_license_discovery(tmpdir):
     out_folder = tmpdir.mkdir("out-license")
-    cli.main(["pypi", "httplib2shim=0.0.3", "-o", str(out_folder)])
+    cli.main(
+        ["pypi", "httplib2shim=0.0.3", "-o", str(out_folder), "--no-use-v1-format"]
+    )
     assert (out_folder / "httplib2shim" / "LICENSE").exists()
 
 
@@ -95,6 +107,13 @@ def test_config_url_pypi_metadata():
     assert config.url_pypi_metadata == "http://url_pypi.com/abc/{pkg_name}/json"
 
 
+@pytest.mark.parametrize("index", ["pypi", "cran"])
+def test_v1_format_is_default(index):
+    parser = cli.init_parser()
+    assert parser.parse_args([index, "pkg"]).use_v1_format
+    assert not parser.parse_args([index, "pkg", "--no-use-v1-format"]).use_v1_format
+
+
 @pytest.mark.parametrize("option", ["-r", "--recursive"])
 def test_recursive_option(mocker, option, tmpdir):
     folder = tmpdir.mkdir(f"recursive_pkg{option}")
@@ -104,7 +123,7 @@ def test_recursive_option(mocker, option, tmpdir):
 
     mocker.patch("grayskull.cli.stdout.is_pkg_available", new=mock_is_pkg_available)
     spy = mocker.spy(cli, "generate_recipes_from_list")
-    cli.main(["pypi", "pytest=5.3.2", option, "-o", str(folder)])
+    cli.main(["pypi", "pytest=5.3.2", option, "-o", str(folder), "--no-use-v1-format"])
     assert spy.call_count == 2
     assert spy.call_args_list[0].args[0] == ["pytest=5.3.2"]
     assert spy.call_args_list[1].args[0] == {"colorama"}
@@ -129,7 +148,9 @@ def test_part_reload_recipe(tmpdir, index, name, version):
     folder = tmpdir.mkdir("reload_recipe")
     recipe_path = folder / "recipe.yaml"
     recipe.save(str(recipe_path))
-    cli.main([index, str(recipe_path), "--sections", "requirements"])
+    cli.main(
+        [index, str(recipe_path), "--sections", "requirements", "--no-use-v1-format"]
+    )
 
     recipe = Recipe(load_file=str(recipe_path))
     assert host == [str(v) for v in recipe["requirements"]["host"] if v]

--- a/tests/cli/test_cli_recipes.py
+++ b/tests/cli/test_cli_recipes.py
@@ -6,7 +6,16 @@ from grayskull.main import main
 def test_loop_deps_nipy_and_maintainers(tmpdir, mocker):
     mocker.patch("grayskull.main.get_git_current_user", return_value="GIT_USER")
     out_folder = tmpdir.mkdir("out")
-    main(["pypi", "nipy=0.4.2", "-o", str(out_folder), "--download"])
+    main(
+        [
+            "pypi",
+            "nipy=0.4.2",
+            "-o",
+            str(out_folder),
+            "--download",
+            "--no-use-v1-format",
+        ]
+    )
     nipy_folder = out_folder / "nipy"
     assert nipy_folder.isdir()
 

--- a/tests/test_py_toml.py
+++ b/tests/test_py_toml.py
@@ -87,7 +87,15 @@ def test_poetry_langchain_snapshot(tmpdir):
     # Check pyproject.toml for version 0.0.119
     # https://inspector.pypi.io/project/langchain/0.0.119
     args = parser.parse_args(
-        ["pypi", "langchain==0.0.119", "-o", str(tmpdir), "-m", "AddYourGitHubIdHere"]
+        [
+            "pypi",
+            "langchain==0.0.119",
+            "-o",
+            str(tmpdir),
+            "-m",
+            "AddYourGitHubIdHere",
+            "--no-use-v1-format",
+        ]
     )
 
     generate_recipes_from_list(args.pypi_packages, args)


### PR DESCRIPTION
## Summary

- generate v1 recipes by default for PyPI and CRAN
- retain v0 output through `--no-use-v1-format`
- update the usage docs and CLI tests

Addresses #630.

## Tests

- `pixi run -e testing pytest tests/cli/test_cli_cmds.py tests/cli/test_cli_recipes.py tests/test_py_toml.py -q`
- `pixi run ruff check grayskull/main.py tests/cli/test_cli_cmds.py tests/cli/test_cli_recipes.py tests/test_py_toml.py`
- `pixi run ruff format --check grayskull/main.py tests/cli/test_cli_cmds.py tests/cli/test_cli_recipes.py tests/test_py_toml.py`
