### PR TITLE
Fix v1 python_version for noarch recipes (#667)

### DIFF
--- a/grayskull/utils.py
+++ b/grayskull/utils.py
@@ -262,16 +262,26 @@ def upgrade_v0_recipe_to_v1(recipe_path: Path) -> None:
         from conda_recipe_manager.parser.recipe_parser_convert import (
             RecipeParserConvert,
         )
+        from conda_recipe_manager.parser.types import RecipeReaderFlags
     except ImportError as e:
         raise ImportError(
             "Please install conda-recipe-manager from conda-forge to enable "
             "support for the V1 format. (Note that Python >=3.11 is required.)"
         ) from e
 
+    # Expand `tests.python.python_version` to a list that tests on both the
+    # pinned Python (e.g. `{{ python_min }}.*`) and the latest Python (`*`).
+    # This is the recommended setting for `noarch: python` packages, see:
+    # https://conda-forge.org/docs/how-to/basics/noarch.html#expressing-python-version-requirements
+    # Tolerate older conda-recipe-manager versions that lack the flag.
+    also_test_latest_python = getattr(RecipeReaderFlags, "ALSO_TEST_LATEST_PYTHON", 0)
+
     recipe_content: Final[str] = RecipeParserConvert.pre_process_recipe_text(
         recipe_path.read_text()
     )
-    recipe_converter = RecipeParserConvert(recipe_content)
+    recipe_converter = RecipeParserConvert(
+        recipe_content, flags=also_test_latest_python
+    )
     v1_content, _, _ = recipe_converter.render_to_v1_recipe_format()
     recipe_path.write_text(v1_content, encoding="utf-8")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from grayskull.utils import (
     merge_list_item,
     origin_is_local_sdist,
     rm_duplicated_deps,
+    upgrade_v0_recipe_to_v1,
 )
 
 
@@ -131,3 +132,53 @@ def test_rm_dupliate_deps_with_star():
     assert rm_duplicated_deps(["typing-extensions", "typing_extensions *"]) == [
         "typing_extensions"
     ]
+
+
+def test_upgrade_v0_recipe_to_v1_python_version_noarch(tmp_path):
+    """V1 conversion should expand `tests.python.python_version` for noarch.
+
+    Regression test for conda/grayskull#667: a `noarch: python` package with a
+    pinned test Python (e.g. `{{ python_min }}.*`) must produce a
+    `python_version` list that also tests the latest Python (`*`).
+    """
+    pytest.importorskip(
+        "conda_recipe_manager", reason="conda-recipe-manager is not installed"
+    )
+    v0 = tmp_path / "meta.yaml"
+    v0.write_text(
+        """\
+package:
+  name: mypkg
+  version: 1.0.0
+
+build:
+  noarch: python
+
+requirements:
+  host:
+    - python {{ python_min }}.*
+    - pip
+  run:
+    - python >={{ python_min }}
+
+test:
+  imports:
+    - mypkg
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}.*
+
+about:
+  home: https://example.com
+  license: MIT
+  summary: test package
+"""
+    )
+    upgrade_v0_recipe_to_v1(v0)
+
+    v1 = v0.read_text()
+    assert "python_version:" in v1
+    assert "{{ python_min }}.*" in v1
+    assert '"*"' in v1 or "'*'" in v1


### PR DESCRIPTION
---
created_at: 2026-08-19T15:52:00Z
repo: conda/grayskull
branch: fix-v1-python-version-noarch
issue: "#667"
fork_branch_url: https://github.com/Rehan30g/grayskull/pull/new/fix-v1-python-version-noarch
---

### Description

Fixes #667

When generating a **v1** recipe for a `noarch: python` PyPI package with
`--use-v1-format`, the resulting `recipe.yaml` only sets
`tests.python.python_version` to the pinned minimum (`${{ python_min }}.*`),
e.g.:

```yaml
tests:
  - python:
      python_version: ${{ python_min }}.*
```

Per the conda-forge docs for noarch packages, this should be a list that
also tests on the latest Python:

```yaml
tests:
  - python:
      python_version:
        - ${{ python_min }}.*
        - "*"
```

See: https://conda-forge.org/docs/how-to/basics/noarch.html#expressing-python-version-requirements

### Cause

`grayskull/utils.py::upgrade_v0_recipe_to_v1` converts the generated v0
recipe to v1 via `conda-recipe-manager`'s `RecipeParserConvert`. It invoked
the converter with the default reader flags, so conda-recipe-manager's
`ALSO_TEST_LATEST_PYTHON` behavior (which expands a pinned `python_version`
into a list that also runs against the latest Python) was never enabled.

### Fix

Pass `RecipeReaderFlags.ALSO_TEST_LATEST_PYTHON` when constructing the
`RecipeParserConvert` instance. The flag only expands `python_version` when
the test section pins a Python version that is not already `*` — which for
grayskull only happens for strict-conda-forge noarch packages. Plain
`python` (no version) test dependencies are unaffected and emit no
`python_version` at all. A `getattr` default keeps compatibility with older
`conda-recipe-manager` releases that predate the flag.

### Testing

- Reproduced the bug: `grayskull pypi --strict-conda-forge --use-v1-format urllib3`
- Verified the fixed output now contains the `python_version` list.
- Added regression test
  `tests/test_utils.py::test_upgrade_v0_recipe_to_v1_python_version_noarch`
  (automatically skipped when `conda-recipe-manager` is not installed).
- `ruff check` and `ruff format --check` pass on the changed files.