### PR TITLE
Map underscored build-system requirements to conda-forge names

### DIFF
--- a/grayskull/strategy/py_toml.py
+++ b/grayskull/strategy/py_toml.py
@@ -1,9 +1,11 @@
+import re
 import sys
 from collections import defaultdict
 from collections.abc import Iterator
 from functools import singledispatch
 from pathlib import Path
 
+from grayskull.base.pkg_info import normalize_pkg_name
 from grayskull.strategy.parse_poetry_version import (
     combine_conda_selectors,
     encode_poetry_platform_to_selector_item,
@@ -11,6 +13,24 @@ from grayskull.strategy.parse_poetry_version import (
     encode_poetry_version,
 )
 from grayskull.utils import nested_dict
+
+RE_REQ_NAME = re.compile(r"^\s*([\.a-zA-Z0-9_-]+)")
+
+
+def normalize_requirement_name(requirement: str) -> str:
+    """Normalize the package name portion of a requirement to the name
+    under which it is actually published on conda-forge (e.g. ``flit_core``
+    -> ``flit-core``), leaving the version specifier untouched.
+    """
+    match = RE_REQ_NAME.match(requirement)
+    if not match:
+        return requirement
+    raw_name = match.group(1)
+    normalized_name = normalize_pkg_name(raw_name)
+    if normalized_name == raw_name:
+        return requirement
+    return requirement.replace(raw_name, normalized_name, 1)
+
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -282,7 +302,10 @@ def get_all_toml_info(path_toml: Path | str) -> dict:
     toml_metadata = defaultdict(dict, toml_metadata)
     metadata = nested_dict()
     toml_project = toml_metadata.get("project", {}) or {}
-    metadata["requirements"]["host"] = toml_metadata["build-system"].get("requires", [])
+    metadata["requirements"]["host"] = [
+        normalize_requirement_name(req)
+        for req in toml_metadata["build-system"].get("requires", [])
+    ]
     metadata["requirements"]["run"] = toml_project.get("dependencies", [])
     metadata["requirements"]["extra"] = toml_project.get("optional-dependencies", {})
     license = toml_project.get("license")

--- a/tests/test_py_toml.py
+++ b/tests/test_py_toml.py
@@ -2,6 +2,7 @@
 
 import filecmp
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -12,6 +13,7 @@ from grayskull.strategy.py_toml import (
     add_poetry_metadata,
     get_all_toml_info,
     get_constrained_dep,
+    normalize_requirement_name,
 )
 
 
@@ -74,6 +76,36 @@ def test_poetry_dependencies():
         "html5lib >=1.0.0,<2.0.0",
         "urllib3 >=1.26.0,<2.0.0",
     ]
+
+
+@mock.patch("grayskull.strategy.py_toml.normalize_pkg_name")
+def test_normalize_requirement_name(mock_normalize_pkg_name):
+    mock_normalize_pkg_name.side_effect = lambda pkg_name: {
+        "flit_core": "flit-core",
+        "setuptools": "setuptools",
+    }[pkg_name]
+
+    assert normalize_requirement_name("flit_core >=3.2,<4") == "flit-core >=3.2,<4"
+    assert normalize_requirement_name("setuptools>=61.0") == "setuptools>=61.0"
+
+
+def test_get_all_toml_info_normalizes_host_requirement_names(tmpdir):
+    """flit_core is published on PyPI with an underscore, but on conda-forge
+    the package is named flit-core. build-system.requires should be
+    normalized to the conda-forge name, same as run/extra requirements
+    already are (see issue #527)."""
+    toml_path = tmpdir / "pyproject.toml"
+    toml_path.write(
+        "[build-system]\n"
+        'requires = ["flit_core >=3.2,<4"]\n'
+        'build-backend = "flit_core.buildapi"\n'
+        "\n"
+        "[project]\n"
+        'name = "some-flit-pkg"\n'
+        'version = "0.1.0"\n'
+    )
+    result = get_all_toml_info(str(toml_path))
+    assert result["requirements"]["host"] == ["flit-core >=3.2,<4"]
 
 
 def test_poetry_langchain_snapshot(tmpdir):


### PR DESCRIPTION
## Description

Closes #527.

`pyproject.toml`'s `[build-system].requires` entries were carried straight into the recipe's host requirements, without going through `normalize_pkg_name()`. That function already exists and is used for run/extra requirements (`merge_requires_dist` in `pypi.py`) precisely because a PyPI name with an underscore is sometimes published on conda-forge under a different, hyphenated name.

`flit_core` is the reported example: it depends on itself at build time via `[build-system].requires = ["flit_core >=3.2,<4"]`, but the conda-forge package is `flit-core`, not `flit_core`. Grayskull generated a recipe requiring a package that doesn't exist on conda-forge.

## Fix

Added `normalize_requirement_name()` in `py_toml.py`, which extracts the package name portion of a requirement string, resolves it through the existing `normalize_pkg_name()`, and rebuilds the requirement with the resolved name (version specifier untouched). `get_all_toml_info()` now applies it to every entry in `build-system.requires` before assigning them to `requirements.host`.

## Tests

- `test_normalize_requirement_name`: unit test for the new helper (name gets rewritten only when different).
- `test_get_all_toml_info_normalizes_host_requirement_names`: end-to-end test with a `flit_core`-based `pyproject.toml`, asserting the generated host requirement is `flit-core >=3.2,<4`.

Ran locally:
- `pytest tests/test_py_toml.py tests/base/test_pkg_info.py` — all passing.
- `ruff check` / `ruff format --check` on the changed files — clean.